### PR TITLE
Use reference types where possible

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
@@ -10,7 +10,7 @@
 	}\
 
 
-bool UglTFRuntimeAsset::LoadFromFilename(const FString Filename)
+bool UglTFRuntimeAsset::LoadFromFilename(const FString& Filename)
 {
 	// asset already loaded ?
 	if (Parser)
@@ -32,7 +32,7 @@ bool UglTFRuntimeAsset::LoadFromFilename(const FString Filename)
 	return Parser != nullptr;
 }
 
-bool UglTFRuntimeAsset::LoadFromString(const FString JsonData)
+bool UglTFRuntimeAsset::LoadFromString(const FString& JsonData)
 {
 	// asset already loaded ?
 	if (Parser)
@@ -54,7 +54,7 @@ bool UglTFRuntimeAsset::LoadFromString(const FString JsonData)
 	return Parser != nullptr;
 }
 
-bool UglTFRuntimeAsset::LoadFromData(const TArray64<uint8> Data)
+bool UglTFRuntimeAsset::LoadFromData(const uint8* DataPtr, int64 DataNum)
 {
 	// asset already loaded ?
 	if (Parser)
@@ -62,7 +62,7 @@ bool UglTFRuntimeAsset::LoadFromData(const TArray64<uint8> Data)
 		return false;
 	}
 
-	Parser = FglTFRuntimeParser::FromData(Data);
+	Parser = FglTFRuntimeParser::FromData(DataPtr, DataNum);
 	if (Parser)
 	{
 		FScriptDelegate Delegate;
@@ -76,7 +76,7 @@ bool UglTFRuntimeAsset::LoadFromData(const TArray64<uint8> Data)
 	return Parser != nullptr;
 }
 
-void UglTFRuntimeAsset::OnErrorProxy(const FString ErrorContext, const FString ErrorMessage)
+void UglTFRuntimeAsset::OnErrorProxy(const FString& ErrorContext, const FString& ErrorMessage)
 {
 	if (OnError.IsBound())
 	{
@@ -207,7 +207,7 @@ TArray<int32> UglTFRuntimeAsset::GetCameraNodesIndices()
 	return NodeIndices;
 }
 
-bool UglTFRuntimeAsset::GetNodeByName(const FString NodeName, FglTFRuntimeNode& Node)
+bool UglTFRuntimeAsset::GetNodeByName(const FString& NodeName, FglTFRuntimeNode& Node)
 {
 	GLTF_CHECK_PARSER(false);
 
@@ -228,7 +228,7 @@ UStaticMesh* UglTFRuntimeAsset::LoadStaticMesh(const int32 MeshIndex, const FglT
 	return Parser->LoadStaticMesh(MeshIndex, StaticMeshConfig);
 }
 
-UStaticMesh* UglTFRuntimeAsset::LoadStaticMeshByName(const FString MeshName, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig)
+UStaticMesh* UglTFRuntimeAsset::LoadStaticMeshByName(const FString& MeshName, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig)
 {
 	GLTF_CHECK_PARSER(nullptr);
 
@@ -256,7 +256,7 @@ UAnimSequence* UglTFRuntimeAsset::LoadSkeletalAnimation(USkeletalMesh* SkeletalM
 	return Parser->LoadSkeletalAnimation(SkeletalMesh, AnimationIndex, SkeletalAnimationConfig);
 }
 
-UAnimSequence* UglTFRuntimeAsset::LoadSkeletalAnimationByName(USkeletalMesh* SkeletalMesh, const FString AnimationName, const FglTFRuntimeSkeletalAnimationConfig SkeletalAnimationConfig)
+UAnimSequence* UglTFRuntimeAsset::LoadSkeletalAnimationByName(USkeletalMesh* SkeletalMesh, const FString& AnimationName, const FglTFRuntimeSkeletalAnimationConfig SkeletalAnimationConfig)
 {
 	GLTF_CHECK_PARSER(nullptr);
 
@@ -328,7 +328,7 @@ bool UglTFRuntimeAsset::BuildTransformFromNodeForward(const int32 NodeIndex, con
 	return true;
 }
 
-UAnimMontage* UglTFRuntimeAsset::LoadSkeletalAnimationAsMontage(USkeletalMesh* SkeletalMesh, const int32 AnimationIndex, const FString SlotNodeName, const FglTFRuntimeSkeletalAnimationConfig AnimationConfig)
+UAnimMontage* UglTFRuntimeAsset::LoadSkeletalAnimationAsMontage(USkeletalMesh* SkeletalMesh, const int32 AnimationIndex, const FString& SlotNodeName, const FglTFRuntimeSkeletalAnimationConfig& AnimationConfig)
 {
 	UAnimSequence* AnimSequence = LoadSkeletalAnimation(SkeletalMesh, AnimationIndex, AnimationConfig);
 	if (!AnimSequence)
@@ -361,14 +361,14 @@ TArray<UglTFRuntimeAnimationCurve*> UglTFRuntimeAsset::LoadAllNodeAnimationCurve
 	return Parser->LoadAllNodeAnimationCurves(NodeIndex);
 }
 
-UAnimSequence* UglTFRuntimeAsset::LoadNodeSkeletalAnimation(USkeletalMesh* SkeletalMesh, const int32 NodeIndex, const FglTFRuntimeSkeletalAnimationConfig SkeletalAnimationConfig)
+UAnimSequence* UglTFRuntimeAsset::LoadNodeSkeletalAnimation(USkeletalMesh* SkeletalMesh, const int32 NodeIndex, const FglTFRuntimeSkeletalAnimationConfig& SkeletalAnimationConfig)
 {
 	GLTF_CHECK_PARSER(nullptr);
 
 	return Parser->LoadNodeSkeletalAnimation(SkeletalMesh, NodeIndex, SkeletalAnimationConfig);
 }
 
-bool UglTFRuntimeAsset::FindNodeByNameInArray(const TArray<int32> NodeIndices, const FString NodeName, FglTFRuntimeNode& Node)
+bool UglTFRuntimeAsset::FindNodeByNameInArray(const TArray<int32>& NodeIndices, const FString& NodeName, FglTFRuntimeNode& Node)
 {
 	GLTF_CHECK_PARSER(false);
 

--- a/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
@@ -151,7 +151,7 @@ void AglTFRuntimeAssetActor::ProcessNode(USceneComponent* NodeParentComponent, F
 	}
 }
 
-void AglTFRuntimeAssetActor::SetCurveAnimationByName(const FString CurveAnimationName)
+void AglTFRuntimeAssetActor::SetCurveAnimationByName(const FString& CurveAnimationName)
 {
 	if (!DiscoveredCurveAnimationsNames.Contains(CurveAnimationName))
 	{

--- a/Source/glTFRuntime/Private/glTFRuntimeFunctionLibrary.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeFunctionLibrary.cpp
@@ -6,7 +6,7 @@
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
 
-UglTFRuntimeAsset* UglTFRuntimeFunctionLibrary::glTFLoadAssetFromFilename(const FString Filename, const bool bPathRelativeToContent)
+UglTFRuntimeAsset* UglTFRuntimeFunctionLibrary::glTFLoadAssetFromFilename(const FString& Filename, const bool bPathRelativeToContent)
 {
 	UglTFRuntimeAsset* Asset = NewObject<UglTFRuntimeAsset>();
 	if (!Asset)
@@ -24,7 +24,7 @@ UglTFRuntimeAsset* UglTFRuntimeFunctionLibrary::glTFLoadAssetFromFilename(const 
 	return Asset;
 }
 
-UglTFRuntimeAsset* UglTFRuntimeFunctionLibrary::glTFLoadAssetFromString(const FString JsonData)
+UglTFRuntimeAsset* UglTFRuntimeFunctionLibrary::glTFLoadAssetFromString(const FString& JsonData)
 {
 	UglTFRuntimeAsset* Asset = NewObject<UglTFRuntimeAsset>();
 	if (!Asset)
@@ -35,7 +35,7 @@ UglTFRuntimeAsset* UglTFRuntimeFunctionLibrary::glTFLoadAssetFromString(const FS
 	return Asset;
 }
 
-void UglTFRuntimeFunctionLibrary::glTFLoadAssetFromUrl(const FString Url, TMap<FString, FString> Headers, FglTFRuntimeHttpResponse Completed)
+void UglTFRuntimeFunctionLibrary::glTFLoadAssetFromUrl(const FString& Url, TMap<FString, FString>& Headers, FglTFRuntimeHttpResponse Completed)
 {
 	TSharedRef<IHttpRequest> HttpRequest = FHttpModule::Get().CreateRequest();
 	HttpRequest->SetURL(Url);
@@ -57,14 +57,12 @@ void UglTFRuntimeFunctionLibrary::glTFLoadAssetFromUrl(const FString Url, TMap<F
 	HttpRequest->ProcessRequest();
 }
 
-UglTFRuntimeAsset* UglTFRuntimeFunctionLibrary::glTFLoadAssetFromData(const TArray<uint8> Data)
+UglTFRuntimeAsset* UglTFRuntimeFunctionLibrary::glTFLoadAssetFromData(const TArray<uint8>& Data)
 {
 	UglTFRuntimeAsset* Asset = NewObject<UglTFRuntimeAsset>();
 	if (!Asset)
 		return nullptr;
-	TArray64<uint8> Data64;
-	Data64.Append(Data);
-	if (!Asset->LoadFromData(Data64))
+	if (!Asset->LoadFromData(Data.GetData(), Data.Num()))
 		return nullptr;
 
 	return Asset;

--- a/Source/glTFRuntime/Public/glTFRuntimeAsset.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeAsset.h
@@ -29,16 +29,16 @@ public:
 	bool GetNode(const int32 NodeIndex, FglTFRuntimeNode& Node);
 
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "glTFRuntime")
-	bool GetNodeByName(const FString NodeName, FglTFRuntimeNode& Node);
+	bool GetNodeByName(const FString& NodeName, FglTFRuntimeNode& Node);
 
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "glTFRuntime")
-	bool FindNodeByNameInArray(const TArray<int32> NodeIndices, const FString NodeName, FglTFRuntimeNode& Node);
+	bool FindNodeByNameInArray(const TArray<int32>& NodeIndices, const FString& NodeName, FglTFRuntimeNode& Node);
 
 	UFUNCTION(BlueprintCallable, meta = (AdvancedDisplay = "StaticMeshConfig", AutoCreateRefTerm = "StaticMeshConfig"), Category = "glTFRuntime")
 	UStaticMesh* LoadStaticMesh(const int32 MeshIndex, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig);
 
 	UFUNCTION(BlueprintCallable, meta = (AdvancedDisplay = "StaticMeshConfig", AutoCreateRefTerm = "StaticMeshConfig"), Category = "glTFRuntime")
-	UStaticMesh* LoadStaticMeshByName(const FString MeshName, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig);
+	UStaticMesh* LoadStaticMeshByName(const FString& MeshName, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig);
 
 	UFUNCTION(BlueprintCallable, meta = (AdvancedDisplay = "SkeletalMeshConfig", AutoCreateRefTerm = "SkeletalMeshConfig"), Category = "glTFRuntime")
 	USkeletalMesh* LoadSkeletalMesh(const int32 MeshIndex, const int32 SkinIndex, const FglTFRuntimeSkeletalMeshConfig SkeletalMeshConfig);
@@ -50,13 +50,13 @@ public:
 	UAnimSequence* LoadSkeletalAnimation(USkeletalMesh* SkeletalMesh, const int32 AnimationIndex, const FglTFRuntimeSkeletalAnimationConfig SkeletalAnimationConfig);
 
 	UFUNCTION(BlueprintCallable, meta = (AdvancedDisplay = "SkeletalAnimationConfig", AutoCreateRefTerm = "SkeletalAnimationConfig"), Category = "glTFRuntime")
-	UAnimSequence* LoadSkeletalAnimationByName(USkeletalMesh* SkeletalMesh, const FString AnimationName, const FglTFRuntimeSkeletalAnimationConfig SkeletalAnimationConfig);
+	UAnimSequence* LoadSkeletalAnimationByName(USkeletalMesh* SkeletalMesh, const FString& AnimationName, const FglTFRuntimeSkeletalAnimationConfig SkeletalAnimationConfig);
 
 	UFUNCTION(BlueprintCallable, meta = (AdvancedDisplay = "SkeletalAnimationConfig", AutoCreateRefTerm = "SkeletalAnimationConfig"), Category = "glTFRuntime")
-	UAnimSequence* LoadNodeSkeletalAnimation(USkeletalMesh* SkeletalMesh, const int32 NodeIndex, const FglTFRuntimeSkeletalAnimationConfig SkeletalAnimationConfig);
+	UAnimSequence* LoadNodeSkeletalAnimation(USkeletalMesh* SkeletalMesh, const int32 NodeIndex, const FglTFRuntimeSkeletalAnimationConfig& SkeletalAnimationConfig);
 
 	UFUNCTION(BlueprintCallable, meta = (AdvancedDisplay = "SkeletalAnimationConfig", AutoCreateRefTerm = "SkeletalAnimationConfig"), Category = "glTFRuntime")
-	UAnimMontage* LoadSkeletalAnimationAsMontage(USkeletalMesh* SkeletalMesh, const int32 AnimationIndex, const FString SlotNodeName, const FglTFRuntimeSkeletalAnimationConfig SkeletalAnimationConfig);
+	UAnimMontage* LoadSkeletalAnimationAsMontage(USkeletalMesh* SkeletalMesh, const int32 AnimationIndex, const FString& SlotNodeName, const FglTFRuntimeSkeletalAnimationConfig& SkeletalAnimationConfig);
 
 	UFUNCTION(BlueprintCallable, Category = "glTFRuntime")
 	UglTFRuntimeAnimationCurve* LoadNodeAnimationCurve(const int32 NodeIndex);
@@ -85,9 +85,11 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "glTFRuntime")
 	bool BuildTransformFromNodeForward(const int32 NodeIndex, const int32 LastNodeIndex, FTransform& Transform);
 
-	bool LoadFromFilename(const FString Filename);
-	bool LoadFromString(const FString JsonData);
-	bool LoadFromData(const TArray64<uint8> Data);
+	bool LoadFromFilename(const FString& Filename);
+	bool LoadFromString(const FString& JsonData);
+	bool LoadFromData(const uint8* DataPtr, int64 DataNum);
+	FORCEINLINE bool LoadFromData(const TArray<uint8>& Data) { return LoadFromData(Data.GetData(), Data.Num()); }
+	FORCEINLINE bool LoadFromData(const TArray64<uint8>& Data) { return LoadFromData(Data.GetData(), Data.Num()); }
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "glTFRuntime")
 	TMap<EglTFRuntimeMaterialType, UMaterialInterface*> MaterialsMap;
@@ -102,7 +104,7 @@ public:
 	FglTFRuntimeOnSkeletalMeshCreated OnSkeletalMeshCreated;
 
 	UFUNCTION()
-	void OnErrorProxy(const FString ErrorContext, const FString ErrorMessage);
+	void OnErrorProxy(const FString& ErrorContext, const FString& ErrorMessage);
 
 	UFUNCTION()
 	void OnStaticMeshCreatedProxy(UStaticMesh* StaticMesh);

--- a/Source/glTFRuntime/Public/glTFRuntimeAssetActor.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeAssetActor.h
@@ -52,7 +52,7 @@ public:
 	void ReceiveOnSkeletalMeshComponentCreated(USkeletalMeshComponent* SkeletalMeshComponent);
 
 	UFUNCTION(BlueprintCallable, Category = "glTFRuntime")
-	void SetCurveAnimationByName(const FString CurveAnimationName);
+	void SetCurveAnimationByName(const FString& CurveAnimationName);
 
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"), Category="glTFRuntime")

--- a/Source/glTFRuntime/Public/glTFRuntimeFunctionLibrary.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeFunctionLibrary.h
@@ -19,15 +19,15 @@ class GLTFRUNTIME_API UglTFRuntimeFunctionLibrary : public UBlueprintFunctionLib
 
 public:
 	UFUNCTION(BlueprintCallable, meta=(DisplayName="glTF Load Asset from Filename"), Category="glTFRuntime")
-	static UglTFRuntimeAsset* glTFLoadAssetFromFilename(const FString Filename, const bool bPathRelativeToContent);
+	static UglTFRuntimeAsset* glTFLoadAssetFromFilename(const FString& Filename, const bool bPathRelativeToContent);
 
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "glTF Load Asset from String"), Category = "glTFRuntime")
-	static UglTFRuntimeAsset* glTFLoadAssetFromString(const FString JsonData);
+	static UglTFRuntimeAsset* glTFLoadAssetFromString(const FString& JsonData);
 
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "glTF Load Asset from Url", AutoCreateRefTerm = "Headers"), Category = "glTFRuntime")
-	static void glTFLoadAssetFromUrl(const FString Url, TMap<FString, FString> Headers, FglTFRuntimeHttpResponse Completed);
+	static void glTFLoadAssetFromUrl(const FString& Url, TMap<FString, FString>& Headers, FglTFRuntimeHttpResponse Completed);
 
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "glTF Load Asset from Data"), Category = "glTFRuntime")
-	static UglTFRuntimeAsset* glTFLoadAssetFromData(const TArray<uint8> Data);
+	static UglTFRuntimeAsset* glTFLoadAssetFromData(const TArray<uint8>& Data);
 	
 };

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -329,6 +329,11 @@ public:
 	static TSharedPtr<FglTFRuntimeParser> FromString(const FString& JsonData);
 	static TSharedPtr<FglTFRuntimeParser> FromData(const uint8* DataPtr, int64 DataNum);
 
+	static FORCEINLINE TSharedPtr<FglTFRuntimeParser> FromBinary(const TArray<uint8> Data) { return FromBinary(Data.GetData(), Data.Num()); }
+	static FORCEINLINE TSharedPtr<FglTFRuntimeParser> FromBinary(const TArray64<uint8> Data) { return FromBinary(Data.GetData(), Data.Num()); }
+	static FORCEINLINE TSharedPtr<FglTFRuntimeParser> FromData(const TArray<uint8> Data) { return FromData(Data.GetData(), Data.Num()); }
+	static FORCEINLINE TSharedPtr<FglTFRuntimeParser> FromData(const TArray64<uint8> Data) { return FromData(Data.GetData(), Data.Num()); }
+
 	UStaticMesh* LoadStaticMesh(const int32 MeshIndex, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig);
 	bool LoadStaticMeshes(TArray<UStaticMesh*>& StaticMeshes, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig);
 

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -321,13 +321,13 @@ struct FglTFRuntimePrimitive
 class GLTFRUNTIME_API FglTFRuntimeParser : public FGCObject
 {
 public:
-	FglTFRuntimeParser(TSharedRef<FJsonObject> JsonObject, FMatrix InSceneBasis, float InSceneScale);
+	FglTFRuntimeParser(TSharedRef<FJsonObject> JsonObject, const FMatrix& InSceneBasis, float InSceneScale);
 	FglTFRuntimeParser(TSharedRef<FJsonObject> JsonObject);
 
-	static TSharedPtr<FglTFRuntimeParser> FromFilename(const FString Filename);
-	static TSharedPtr<FglTFRuntimeParser> FromBinary(const TArray64<uint8> Data);
-	static TSharedPtr<FglTFRuntimeParser> FromString(const FString JsonData);
-	static TSharedPtr<FglTFRuntimeParser> FromData(const TArray64<uint8> Data);
+	static TSharedPtr<FglTFRuntimeParser> FromFilename(const FString& Filename);
+	static TSharedPtr<FglTFRuntimeParser> FromBinary(const uint8* DataPtr, int64 DataNum);
+	static TSharedPtr<FglTFRuntimeParser> FromString(const FString& JsonData);
+	static TSharedPtr<FglTFRuntimeParser> FromData(const uint8* DataPtr, int64 DataNum);
 
 	UStaticMesh* LoadStaticMesh(const int32 MeshIndex, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig);
 	bool LoadStaticMeshes(TArray<UStaticMesh*>& StaticMeshes, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig);
@@ -364,16 +364,16 @@ public:
 	bool LoadCameraIntoCameraComponent(const int32 CameraIndex, UCameraComponent* CameraComponent);
 
 	int64 GetComponentTypeSize(const int64 ComponentType) const;
-	int64 GetTypeSize(const FString Type) const;
+	int64 GetTypeSize(const FString& Type) const;
 
-	bool ParseBase64Uri(const FString Uri, TArray64<uint8>& Bytes);
+	bool ParseBase64Uri(const FString& Uri, TArray64<uint8>& Bytes);
 
 	void AddReferencedObjects(FReferenceCollector& Collector);
 
 	bool LoadPrimitives(const TArray<TSharedPtr<FJsonValue>>* JsonPrimitives, TArray<FglTFRuntimePrimitive>& Primitives, const FglTFRuntimeMaterialsConfig& MaterialsConfig);
 	bool LoadPrimitive(TSharedRef<FJsonObject> JsonPrimitiveObject, FglTFRuntimePrimitive& Primitive, const FglTFRuntimeMaterialsConfig& MaterialsConfig);
 
-	void AddError(const FString ErrorContext, const FString ErrorMessage);
+	void AddError(const FString& ErrorContext, const FString& ErrorMessage);
 	void ClearErrors();
 
 	bool NodeIsBone(const int32 NodeIndex);
@@ -382,7 +382,7 @@ public:
 	FglTFRuntimeOnStaticMeshCreated OnStaticMeshCreated;
 	FglTFRuntimeOnSkeletalMeshCreated OnSkeletalMeshCreated;
 
-	void SetBinaryBuffer(TArray64<uint8>& InBinaryBuffer)
+	void SetBinaryBuffer(const TArray64<uint8>& InBinaryBuffer)
 	{
 		BinaryBuffer = InBinaryBuffer;
 	}
@@ -417,21 +417,21 @@ protected:
 
 	void FixNodeParent(FglTFRuntimeNode& Node);
 
-	int32 FindCommonRoot(TArray<int32> NodeIndices);
+	int32 FindCommonRoot(const TArray<int32>& NodeIndices);
 	int32 FindTopRoot(int32 NodeIndex);
 	bool HasRoot(int32 NodeIndex, int32 RootIndex);
 
-	bool CheckJsonIndex(TSharedRef<FJsonObject> JsonObject, const FString FieldName, const int32 Index, TArray<TSharedRef<FJsonValue>>& JsonItems);
+	bool CheckJsonIndex(TSharedRef<FJsonObject> JsonObject, const FString& FieldName, const int32 Index, TArray<TSharedRef<FJsonValue>>& JsonItems);
 	bool CheckJsonRootIndex(const FString FieldName, const int32 Index, TArray<TSharedRef<FJsonValue>>& JsonItems) { return CheckJsonIndex(Root, FieldName, Index, JsonItems); }
-	TSharedPtr<FJsonObject> GetJsonObjectFromIndex(TSharedRef<FJsonObject> JsonObject, const FString FieldName, const int32 Index);
-	TSharedPtr<FJsonObject> GetJsonObjectFromRootIndex(const FString FieldName, const int32 Index) { return GetJsonObjectFromIndex(Root, FieldName, Index); }
+	TSharedPtr<FJsonObject> GetJsonObjectFromIndex(TSharedRef<FJsonObject> JsonObject, const FString& FieldName, const int32 Index);
+	TSharedPtr<FJsonObject> GetJsonObjectFromRootIndex(const FString& FieldName, const int32 Index) { return GetJsonObjectFromIndex(Root, FieldName, Index); }
 
-	FString GetJsonObjectString(TSharedRef<FJsonObject> JsonObject, const FString FieldName, const FString DefaultValue);
-	int32 GetJsonObjectIndex(TSharedRef<FJsonObject> JsonObject, const FString FieldName, const int32 DefaultValue);
+	FString GetJsonObjectString(TSharedRef<FJsonObject> JsonObject, const FString& FieldName, const FString& DefaultValue);
+	int32 GetJsonObjectIndex(TSharedRef<FJsonObject> JsonObject, const FString& FieldName, const int32 DefaultValue);
 
 	bool FillJsonMatrix(const TArray<TSharedPtr<FJsonValue>>* JsonMatrixValues, FMatrix& Matrix);
 
-	float FindBestFrames(TArray<float> FramesTimes, float WantedTime, int32& FirstIndex, int32& SecondIndex);
+	float FindBestFrames(const TArray<float>& FramesTimes, float WantedTime, int32& FirstIndex, int32& SecondIndex);
 
 	void NormalizeSkeletonScale(FReferenceSkeleton& RefSkeleton);
 	void NormalizeSkeletonBoneScale(FReferenceSkeletonModifier& Modifier, const int32 BoneIndex, FVector BoneScale);
@@ -449,7 +449,7 @@ protected:
 	TArray<FString> Errors;
 
 	template<typename T, typename Callback>
-	bool BuildFromAccessorField(TSharedRef<FJsonObject> JsonObject, const FString Name, TArray<T>& Data, const TArray<int64> SupportedElements, const TArray<int64> SupportedTypes, const bool bNormalized, Callback Filter)
+	bool BuildFromAccessorField(TSharedRef<FJsonObject> JsonObject, const FString& Name, TArray<T>& Data, const TArray<int64>& SupportedElements, const TArray<int64>& SupportedTypes, const bool bNormalized, Callback Filter)
 	{
 		int64 AccessorIndex;
 		if (!JsonObject->TryGetNumberField(Name, AccessorIndex))
@@ -528,7 +528,7 @@ protected:
 	}
 
 	template<typename T, typename Callback>
-	bool BuildFromAccessorField(TSharedRef<FJsonObject> JsonObject, const FString Name, TArray<T>& Data, const TArray<int64> SupportedTypes, const bool bNormalized, Callback Filter)
+	bool BuildFromAccessorField(TSharedRef<FJsonObject> JsonObject, const FString& Name, TArray<T>& Data, const TArray<int64>& SupportedTypes, const bool bNormalized, Callback Filter)
 	{
 		int64 AccessorIndex;
 		if (!JsonObject->TryGetNumberField(Name, AccessorIndex))
@@ -593,13 +593,13 @@ protected:
 	}
 
 	template<typename T>
-	bool BuildFromAccessorField(TSharedRef<FJsonObject> JsonObject, const FString Name, TArray<T>& Data, const TArray<int64> SupportedElements, const TArray<int64> SupportedTypes, const bool bNormalized)
+	bool BuildFromAccessorField(TSharedRef<FJsonObject> JsonObject, const FString& Name, TArray<T>& Data, const TArray<int64>& SupportedElements, const TArray<int64>& SupportedTypes, const bool bNormalized)
 	{
 		return BuildFromAccessorField(JsonObject, Name, Data, SupportedElements, SupportedTypes, bNormalized, [&](T InValue) -> T {return InValue; });
 	}
 
 	template<typename T>
-	bool BuildFromAccessorField(TSharedRef<FJsonObject> JsonObject, const FString Name, TArray<T>& Data, const TArray<int64> SupportedTypes, const bool bNormalized)
+	bool BuildFromAccessorField(TSharedRef<FJsonObject> JsonObject, const FString& Name, TArray<T>& Data, const TArray<int64>& SupportedTypes, const bool bNormalized)
 	{
 		return BuildFromAccessorField(JsonObject, Name, Data, SupportedTypes, bNormalized, [&](T InValue) -> T {return InValue; });
 	}


### PR DESCRIPTION
Hi

This PR changes const parameters of big things (strings and arrays) to reference instead of value types.
I also changed some internal data loading function to use pointer+length to accommodate both TArray and TArray64 interfaces.

Just adding a & to an already const parameter does not change the Blueprint interface or how the nodes are shown in the Blueprint editor so no Blueprint updates or recompiling required with this change. Similarly the C++ interface does not change and no code update should be needed.

One exception are two changes to the class `FglTFRuntimeParser` where I changed the array parameters to more flexible pointer+length variants.
If you think these functions are commonly publicly used outside the library, it would make sense to add wrapper functions back in like this:
```c++
static FORCEINLINE TSharedPtr<FglTFRuntimeParser> FromBinary(const TArray64<uint8> Data) { return FromBinary(Data.GetData(), Data.Num()); }
static FORCEINLINE TSharedPtr<FglTFRuntimeParser> FromData(const TArray64<uint8> Data) { return FromData(Data.GetData(), Data.Num()); }
```

Cheers