### PR TITLE
TSharedPtr thread safety

### DIFF
--- a/Source/glTFRuntime/glTFRuntime.Build.cs
+++ b/Source/glTFRuntime/glTFRuntime.Build.cs
@@ -65,5 +65,7 @@ public class glTFRuntime : ModuleRules
 				// ... add any modules that your module loads dynamically here ...
 			}
             );
+
+        PublicDefinitions.Add("PLATFORM_WEAKLY_CONSISTENT_MEMORY=1");
     }
 }


### PR DESCRIPTION
**The issue:**
I have entered an occasional crash when importing large glTF models at runtime. 
After looking into the issue, the crash seemed to be caused by multiple threads incrementing/decrementing the SharedReferenceCount of a TSharedPtr pointing to a FJsonValueArray (usually the "bufferViews" array). This operation is not atomic by default.

**The fix:**
[Since TSharedPtr is not thread-safe by default](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/UnrealArchitecture/SmartPointerLibrary/#threadsafety), we have to change the Mode-parameter of MakeShared when creating the shared pointers. However, since MakeShared is called by Unreal's JsonSerializer (which uses the default Mode) we can't control how each shared pointer is constructed and will instead need to change the default shared pointer Mode for the whole plugin.

For reference, see the[ implementation of MakeShared in SharedPointer.h.](https://github.com/EpicGames/UnrealEngine/blob/a47b87395132f0454c285dc6ec488dece4d45c9c/Engine/Source/Runtime/Core/Public/Templates/SharedPointer.h#L1841) The Mode is set to _ESPMode::Fast_ by default, which will be thread safe only if FORCE_THREADSAFE_SHAREDPTRS (or PLATFORM_WEAKLY_CONSISTENT_MEMORY) is set to 1.