### PR TITLE
[+] Add SCOPED_NAMED_EVENT to significant methods for CPU profiling

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
@@ -143,6 +143,7 @@ bool UglTFRuntimeAsset::GetNode(const int32 NodeIndex, FglTFRuntimeNode& Node)
 
 ACameraActor* UglTFRuntimeAsset::LoadNodeCamera(UObject* WorldContextObject, const int32 NodeIndex, TSubclassOf<ACameraActor> CameraActorClass)
 {
+	SCOPED_NAMED_EVENT(UglTFRuntimeAsset_LoadNodeCamera, FColor::Cyan);
 	GLTF_CHECK_PARSER(nullptr);
 
 	if (!CameraActorClass)
@@ -195,6 +196,7 @@ bool UglTFRuntimeAsset::LoadCamera(const int32 CameraIndex, UCameraComponent* Ca
 
 TArray<int32> UglTFRuntimeAsset::GetCameraNodesIndices()
 {
+	SCOPED_NAMED_EVENT(UglTFRuntimeAsset_GetCameraNodesIndices, FColor::Cyan);
 	TArray<int32> NodeIndices;
 
 	GLTF_CHECK_PARSER(NodeIndices);
@@ -328,6 +330,8 @@ UAnimSequence* UglTFRuntimeAsset::LoadSkeletalAnimationByName(USkeletalMesh* Ske
 
 bool UglTFRuntimeAsset::BuildTransformFromNodeBackward(const int32 NodeIndex, FTransform& Transform)
 {
+	SCOPED_NAMED_EVENT(UglTFRuntimeAsset_BuildTransformFromNodeBackward, FColor::Cyan);
+
 	GLTF_CHECK_PARSER(false);
 
 	Transform = FTransform::Identity;
@@ -356,6 +360,8 @@ bool UglTFRuntimeAsset::NodeIsBone(const int32 NodeIndex)
 
 bool UglTFRuntimeAsset::BuildTransformFromNodeForward(const int32 NodeIndex, const int32 LastNodeIndex, FTransform& Transform)
 {
+	SCOPED_NAMED_EVENT(UglTFRuntimeAsset_BuildTransformFromNodeForward, FColor::Cyan);
+	
 	GLTF_CHECK_PARSER(false);
 
 	Transform = FTransform::Identity;
@@ -393,6 +399,8 @@ bool UglTFRuntimeAsset::BuildTransformFromNodeForward(const int32 NodeIndex, con
 
 UAnimMontage* UglTFRuntimeAsset::LoadSkeletalAnimationAsMontage(USkeletalMesh* SkeletalMesh, const int32 AnimationIndex, const FString& SlotNodeName, const FglTFRuntimeSkeletalAnimationConfig& AnimationConfig)
 {
+	SCOPED_NAMED_EVENT(UglTFRuntimeAsset_LoadSkeletalAnimationAsMontage, FColor::Cyan);
+
 	UAnimSequence* AnimSequence = LoadSkeletalAnimation(SkeletalMesh, AnimationIndex, AnimationConfig);
 	if (!AnimSequence)
 	{
@@ -433,6 +441,8 @@ UAnimSequence* UglTFRuntimeAsset::LoadNodeSkeletalAnimation(USkeletalMesh* Skele
 
 bool UglTFRuntimeAsset::FindNodeByNameInArray(const TArray<int32>& NodeIndices, const FString& NodeName, FglTFRuntimeNode& Node)
 {
+	SCOPED_NAMED_EVENT(UglTFRuntimeAsset_FindNodeByNameInArray, FColor::Cyan);
+
 	GLTF_CHECK_PARSER(false);
 
 	for (int32 NodeIndex : NodeIndices)

--- a/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
@@ -21,6 +21,8 @@ void AglTFRuntimeAssetActor::BeginPlay()
 {
 	Super::BeginPlay();
 
+	SCOPED_NAMED_EVENT(AglTFRuntimeAssetActor_BeginPlay, FColor::Cyan);
+
 	if (!Asset)
 	{
 		return;
@@ -47,6 +49,8 @@ void AglTFRuntimeAssetActor::BeginPlay()
 
 void AglTFRuntimeAssetActor::ProcessNode(USceneComponent* NodeParentComponent, FglTFRuntimeNode& Node)
 {
+	SCOPED_NAMED_EVENT(AglTFRuntimeAssetActor_ProcessNode, FColor::Cyan);
+
 	// skip bones/joints
 	if (Asset->NodeIsBone(Node.Index))
 	{
@@ -182,6 +186,8 @@ void AglTFRuntimeAssetActor::ProcessNode(USceneComponent* NodeParentComponent, F
 
 void AglTFRuntimeAssetActor::SetCurveAnimationByName(const FString& CurveAnimationName)
 {
+	SCOPED_NAMED_EVENT(AglTFRuntimeAssetActor_SetCurveAnimationByName, FColor::Cyan);
+
 	if (!DiscoveredCurveAnimationsNames.Contains(CurveAnimationName))
 	{
 		return;
@@ -208,6 +214,7 @@ void AglTFRuntimeAssetActor::SetCurveAnimationByName(const FString& CurveAnimati
 // Called every frame
 void AglTFRuntimeAssetActor::Tick(float DeltaTime)
 {
+	SCOPED_NAMED_EVENT(AglTFRuntimeAssetActor_Tick, FColor::Cyan);
 	Super::Tick(DeltaTime);
 
 	for (TPair<USceneComponent*, UglTFRuntimeAnimationCurve*>& Pair : CurveBasedAnimations)

--- a/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
@@ -13,6 +13,8 @@ DEFINE_LOG_CATEGORY(LogGLTFRuntime);
 
 TSharedPtr<FglTFRuntimeParser> FglTFRuntimeParser::FromFilename(const FString& Filename, const FglTFRuntimeConfig& LoaderConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FromFilename, FColor::Cyan);
+
 	FString TruePath = Filename;
 
 	if (LoaderConfig.bSearchContentDir)
@@ -64,6 +66,8 @@ TSharedPtr<FglTFRuntimeParser> FglTFRuntimeParser::FromFilename(const FString& F
 
 TSharedPtr<FglTFRuntimeParser> FglTFRuntimeParser::FromData(const uint8* DataPtr, int64 DataNum, const FglTFRuntimeConfig& LoaderConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FromData, FColor::Cyan);
+
 	// required for Gzip;
 	TArray<uint8> UncompressedData;
 
@@ -220,6 +224,8 @@ TSharedPtr<FglTFRuntimeParser> FglTFRuntimeParser::FromData(const uint8* DataPtr
 
 TSharedPtr<FglTFRuntimeParser> FglTFRuntimeParser::FromString(const FString& JsonData, const FglTFRuntimeConfig& LoaderConfig, TSharedPtr<FglTFRuntimeZipFile> InZipFile)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FromString, FColor::Cyan);
+
 	TSharedPtr<FJsonValue> RootValue;
 
 	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(JsonData);
@@ -256,6 +262,8 @@ TSharedPtr<FglTFRuntimeParser> FglTFRuntimeParser::FromString(const FString& Jso
 
 TSharedPtr<FglTFRuntimeParser> FglTFRuntimeParser::FromBinary(const uint8* DataPtr, int64 DataNum, const FglTFRuntimeConfig& LoaderConfig, TSharedPtr<FglTFRuntimeZipFile> InZipFile)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FromBinary, FColor::Cyan);
+
 	FString JsonData;
 	TArray64<uint8> BinaryBuffer;
 
@@ -315,6 +323,8 @@ TSharedPtr<FglTFRuntimeParser> FglTFRuntimeParser::FromBinary(const uint8* DataP
 
 FglTFRuntimeParser::FglTFRuntimeParser(TSharedRef<FJsonObject> JsonObject, const FMatrix& InSceneBasis, float InSceneScale) : Root(JsonObject), SceneBasis(InSceneBasis), SceneScale(InSceneScale)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_Constructor, FColor::Cyan);
+
 	bAllNodesCached = false;
 
 	UMaterialInterface* OpaqueMaterial = LoadObject<UMaterialInterface>(nullptr, TEXT("/glTFRuntime/M_glTFRuntimeBase"));
@@ -369,6 +379,8 @@ FglTFRuntimeParser::FglTFRuntimeParser(TSharedRef<FJsonObject> JsonObject, const
 
 bool FglTFRuntimeParser::LoadNodes()
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadNodes, FColor::Cyan);
+
 	if (bAllNodesCached)
 	{
 		return true;
@@ -416,6 +428,8 @@ void FglTFRuntimeParser::FixNodeParent(FglTFRuntimeNode& Node)
 
 bool FglTFRuntimeParser::LoadNodesRecursive(const int32 NodeIndex, TArray<FglTFRuntimeNode>& Nodes)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadNodesRecursive, FColor::Cyan);
+
 	FglTFRuntimeNode Node;
 	if (!LoadNode(NodeIndex, Node))
 	{
@@ -438,6 +452,8 @@ bool FglTFRuntimeParser::LoadNodesRecursive(const int32 NodeIndex, TArray<FglTFR
 
 bool FglTFRuntimeParser::LoadScenes(TArray<FglTFRuntimeScene>& Scenes)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadScenes, FColor::Cyan);
+
 	const TArray<TSharedPtr<FJsonValue>>* JsonScenes;
 	// no scenes ?
 	if (!Root->TryGetArrayField("scenes", JsonScenes))
@@ -609,6 +625,8 @@ TArray<int32> FglTFRuntimeParser::GetJsonExtensionObjectIndices(TSharedRef<FJson
 
 bool FglTFRuntimeParser::LoadScene(int32 SceneIndex, FglTFRuntimeScene& Scene)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadScene, FColor::Cyan);
+
 	TSharedPtr<FJsonObject> JsonSceneObject = GetJsonObjectFromRootIndex("scenes", SceneIndex);
 	if (!JsonSceneObject)
 	{
@@ -638,6 +656,8 @@ bool FglTFRuntimeParser::LoadScene(int32 SceneIndex, FglTFRuntimeScene& Scene)
 
 bool FglTFRuntimeParser::GetAllNodes(TArray<FglTFRuntimeNode>& Nodes)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetAllNodes, FColor::Cyan);
+
 	if (!bAllNodesCached)
 	{
 		if (!LoadNodes())
@@ -651,6 +671,8 @@ bool FglTFRuntimeParser::GetAllNodes(TArray<FglTFRuntimeNode>& Nodes)
 
 bool FglTFRuntimeParser::LoadNode(int32 Index, FglTFRuntimeNode& Node)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadNode, FColor::Cyan);
+
 	// a bit hacky, but allows zero-copy for cached values
 	if (!bAllNodesCached)
 	{
@@ -667,6 +689,8 @@ bool FglTFRuntimeParser::LoadNode(int32 Index, FglTFRuntimeNode& Node)
 
 bool FglTFRuntimeParser::LoadNodeByName(const FString& Name, FglTFRuntimeNode& Node)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadNodeByName, FColor::Cyan);
+
 	// a bit hacky, but allows zero-copy for cached values
 	if (!bAllNodesCached)
 	{
@@ -706,6 +730,8 @@ void FglTFRuntimeParser::ClearErrors()
 
 bool FglTFRuntimeParser::FillJsonMatrix(const TArray<TSharedPtr<FJsonValue>>* JsonMatrixValues, FMatrix& Matrix)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FillJsonMatrix, FColor::Cyan);
+
 	if (JsonMatrixValues->Num() != 16)
 		return false;
 
@@ -725,6 +751,8 @@ bool FglTFRuntimeParser::FillJsonMatrix(const TArray<TSharedPtr<FJsonValue>>* Js
 
 bool FglTFRuntimeParser::LoadNode_Internal(int32 Index, TSharedRef<FJsonObject> JsonNodeObject, int32 NodesCount, FglTFRuntimeNode& Node)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadNode_Internal, FColor::Cyan);
+
 	Node.Index = Index;
 	Node.Name = GetJsonObjectString(JsonNodeObject, "name", FString::FromInt(Node.Index));
 
@@ -809,6 +837,8 @@ bool FglTFRuntimeParser::LoadNode_Internal(int32 Index, TSharedRef<FJsonObject> 
 
 bool FglTFRuntimeParser::LoadAnimation_Internal(TSharedRef<FJsonObject> JsonAnimationObject, float& Duration, FString& Name, TFunctionRef<void(const FglTFRuntimeNode& Node, const FString& Path, const TArray<float> Timeline, const TArray<FVector4> Values)> Callback, TFunctionRef<bool(const FglTFRuntimeNode& Node)> NodeFilter)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadAnimation_Internal, FColor::Cyan);
+
 	Name = GetJsonObjectString(JsonAnimationObject, "name", "");
 
 	const TArray<TSharedPtr<FJsonValue>>* JsonSamplers;
@@ -914,6 +944,8 @@ bool FglTFRuntimeParser::LoadAnimation_Internal(TSharedRef<FJsonObject> JsonAnim
 
 TArray<FString> FglTFRuntimeParser::GetCamerasNames()
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetCamerasNames, FColor::Cyan);
+
 	TArray<FString> CamerasNames;
 	const TArray<TSharedPtr<FJsonValue>>* JsonCameras;
 	if (!Root->TryGetArrayField("cameras", JsonCameras))
@@ -943,6 +975,8 @@ TArray<FString> FglTFRuntimeParser::GetCamerasNames()
 
 UglTFRuntimeAnimationCurve* FglTFRuntimeParser::LoadNodeAnimationCurve(const int32 NodeIndex)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadNodeAnimationCurve, FColor::Cyan);
+
 	FglTFRuntimeNode Node;
 	if (!LoadNode(NodeIndex, Node))
 		return nullptr;
@@ -1032,6 +1066,8 @@ UglTFRuntimeAnimationCurve* FglTFRuntimeParser::LoadNodeAnimationCurve(const int
 
 TArray<UglTFRuntimeAnimationCurve*> FglTFRuntimeParser::LoadAllNodeAnimationCurves(const int32 NodeIndex)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadAllNodeAnimationCurves, FColor::Cyan);
+
 	TArray<UglTFRuntimeAnimationCurve*> AnimationCurves;
 
 	FglTFRuntimeNode Node;
@@ -1124,6 +1160,8 @@ TArray<UglTFRuntimeAnimationCurve*> FglTFRuntimeParser::LoadAllNodeAnimationCurv
 
 bool FglTFRuntimeParser::HasRoot(int32 Index, int32 RootIndex)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_HasRoot, FColor::Cyan);
+
 	if (Index == RootIndex)
 		return true;
 
@@ -1144,6 +1182,8 @@ bool FglTFRuntimeParser::HasRoot(int32 Index, int32 RootIndex)
 
 int32 FglTFRuntimeParser::FindTopRoot(int32 Index)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FindTopRoot, FColor::Cyan);
+
 	FglTFRuntimeNode Node;
 	if (!LoadNode(Index, Node))
 		return INDEX_NONE;
@@ -1158,6 +1198,8 @@ int32 FglTFRuntimeParser::FindTopRoot(int32 Index)
 
 int32 FglTFRuntimeParser::FindCommonRoot(const TArray<int32>& Indices)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FindCommonRoot, FColor::Cyan);
+
 	int32 CurrentRootIndex = Indices[0];
 	bool bTryNextParent = true;
 
@@ -1184,6 +1226,8 @@ int32 FglTFRuntimeParser::FindCommonRoot(const TArray<int32>& Indices)
 
 bool FglTFRuntimeParser::LoadCameraIntoCameraComponent(const int32 CameraIndex, UCameraComponent* CameraComponent)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadCameraIntoCameraComponent, FColor::Cyan);
+
 	if (!CameraComponent)
 	{
 		AddError("LoadCameraIntoCameraComponent()", "No valid CameraComponent specified.");
@@ -1272,6 +1316,8 @@ bool FglTFRuntimeParser::LoadCameraIntoCameraComponent(const int32 CameraIndex, 
 
 USkeleton* FglTFRuntimeParser::LoadSkeleton(const int32 SkinIndex, const FglTFRuntimeSkeletonConfig& SkeletonConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeleton, FColor::Cyan);
+
 	TSharedPtr<FJsonObject> JsonSkinObject = GetJsonObjectFromRootIndex("skins", SkinIndex);
 	if (!JsonSkinObject)
 	{
@@ -1321,6 +1367,8 @@ USkeleton* FglTFRuntimeParser::LoadSkeleton(const int32 SkinIndex, const FglTFRu
 
 bool FglTFRuntimeParser::NodeIsBone(const int32 NodeIndex)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_NodeIsBone, FColor::Cyan);
+
 	const TArray<TSharedPtr<FJsonValue>>* JsonSkins;
 	if (!Root->TryGetArrayField("skins", JsonSkins))
 	{
@@ -1360,6 +1408,8 @@ bool FglTFRuntimeParser::NodeIsBone(const int32 NodeIndex)
 
 bool FglTFRuntimeParser::FillFakeSkeleton(FReferenceSkeleton& RefSkeleton, TMap<int32, FName>& BoneMap, const FglTFRuntimeSkeletalMeshConfig& SkeletalMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FillFakeSkeleton, FColor::Cyan);
+
 	RefSkeleton.Empty();
 
 	FReferenceSkeletonModifier Modifier = FReferenceSkeletonModifier(RefSkeleton, nullptr);
@@ -1427,6 +1477,8 @@ bool FglTFRuntimeParser::FillFakeSkeleton(FReferenceSkeleton& RefSkeleton, TMap<
 
 bool FglTFRuntimeParser::FillReferenceSkeleton(TSharedRef<FJsonObject> JsonSkinObject, FReferenceSkeleton& RefSkeleton, TMap<int32, FName>& BoneMap, const FglTFRuntimeSkeletonConfig& SkeletonConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FillReferenceSkeleton, FColor::Cyan);
+
 	// get the list of valid joints	
 	const TArray<TSharedPtr<FJsonValue>>* JsonJoints;
 	TArray<int32> Joints;
@@ -1539,6 +1591,8 @@ bool FglTFRuntimeParser::FillReferenceSkeleton(TSharedRef<FJsonObject> JsonSkinO
 
 bool FglTFRuntimeParser::TraverseJoints(FReferenceSkeletonModifier& Modifier, int32 Parent, FglTFRuntimeNode& Node, const TArray<int32>& Joints, TMap<int32, FName>& BoneMap, const TMap<int32, FMatrix>& InverseBindMatricesMap, const FglTFRuntimeSkeletonConfig& SkeletonConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_TraverseJoints, FColor::Cyan);
+
 	// add fake root bone ?
 	if (Parent == INDEX_NONE && SkeletonConfig.bAddRootBone)
 	{
@@ -1618,6 +1672,8 @@ bool FglTFRuntimeParser::TraverseJoints(FReferenceSkeletonModifier& Modifier, in
 
 bool FglTFRuntimeParser::LoadPrimitives(TSharedRef<FJsonObject> JsonMeshObject, TArray<FglTFRuntimePrimitive>& Primitives, const FglTFRuntimeMaterialsConfig& MaterialsConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadPrimitives, FColor::Cyan);
+
 	// get primitives
 	const TArray<TSharedPtr<FJsonValue>>* JsonPrimitives;
 	if (!JsonMeshObject->TryGetArrayField("primitives", JsonPrimitives))
@@ -1720,6 +1776,8 @@ bool FglTFRuntimeParser::LoadPrimitives(TSharedRef<FJsonObject> JsonMeshObject, 
 
 bool FglTFRuntimeParser::LoadPrimitive(TSharedRef<FJsonObject> JsonPrimitiveObject, FglTFRuntimePrimitive& Primitive, const FglTFRuntimeMaterialsConfig& MaterialsConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadPrimitive, FColor::Cyan);
+
 	const TSharedPtr<FJsonObject>* JsonAttributesObject;
 	if (!JsonPrimitiveObject->TryGetObjectField("attributes", JsonAttributesObject))
 	{
@@ -2461,6 +2519,8 @@ float FglTFRuntimeParser::FindBestFrames(const TArray<float>& FramesTimes, float
 
 bool FglTFRuntimeParser::MergePrimitives(TArray<FglTFRuntimePrimitive> SourcePrimitives, FglTFRuntimePrimitive& OutPrimitive)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_MergePrimitives, FColor::Cyan);
+
 	if (SourcePrimitives.Num() < 1)
 	{
 		return false;
@@ -2564,6 +2624,8 @@ bool FglTFRuntimeParser::MergePrimitives(TArray<FglTFRuntimePrimitive> SourcePri
 
 bool FglTFRuntimeParser::GetMorphTargetNames(const int32 MeshIndex, TArray<FName>& MorphTargetNames)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetMorphTargetNames, FColor::Cyan);
+
 	TSharedPtr<FJsonObject> JsonMeshObject = GetJsonObjectFromRootIndex("meshes", MeshIndex);
 	if (!JsonMeshObject)
 	{
@@ -2622,6 +2684,8 @@ bool FglTFRuntimeParser::GetMorphTargetNames(const int32 MeshIndex, TArray<FName
 
 bool FglTFRuntimeZipFile::FromData(const uint8* DataPtr, const int64 DataNum)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FromData, FColor::Cyan);
+
 	Data.Append(DataPtr, DataNum);
 
 	// step0: retrieve the trailer magic
@@ -2713,6 +2777,8 @@ bool FglTFRuntimeZipFile::FromData(const uint8* DataPtr, const int64 DataNum)
 
 bool FglTFRuntimeZipFile::GetFileContent(const FString& Filename, TArray64<uint8>& OutData)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetFileContent, FColor::Cyan);
+
 	uint32* Offset = OffsetsMap.Find(Filename);
 	if (!Offset)
 	{

--- a/Source/glTFRuntime/Private/glTFRuntimeParserCustom.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserCustom.cpp
@@ -4,6 +4,8 @@
 
 TSharedPtr<FJsonValue> FglTFRuntimeParser::GetJSONObjectFromPath(const TArray<FglTFRuntimePathItem>& Path) const
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetJSONObjectFromPath, FColor::Cyan);
+
 	if (Path.Num() == 0)
 	{
 		return nullptr;
@@ -80,6 +82,8 @@ TSharedPtr<FJsonValue> FglTFRuntimeParser::GetJSONObjectFromPath(const TArray<Fg
 
 FString FglTFRuntimeParser::GetJSONStringFromPath(const TArray<FglTFRuntimePathItem>& Path, bool& bFound) const
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetJSONStringFromPath, FColor::Cyan);
+
 	FString ReturnValue = "";
 	bFound = false;
 
@@ -96,6 +100,8 @@ FString FglTFRuntimeParser::GetJSONStringFromPath(const TArray<FglTFRuntimePathI
 
 double FglTFRuntimeParser::GetJSONNumberFromPath(const TArray<FglTFRuntimePathItem>& Path, bool& bFound) const
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetJSONNumberFromPath, FColor::Cyan);
+
 	double ReturnValue = 0;
 	bFound = false;
 
@@ -111,6 +117,8 @@ double FglTFRuntimeParser::GetJSONNumberFromPath(const TArray<FglTFRuntimePathIt
 
 bool FglTFRuntimeParser::GetJSONBooleanFromPath(const TArray<FglTFRuntimePathItem>& Path, bool& bFound) const
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetJSONBooleanFromPath, FColor::Cyan);
+
 	bool ReturnValue = false;
 	bFound = false;
 
@@ -126,6 +134,8 @@ bool FglTFRuntimeParser::GetJSONBooleanFromPath(const TArray<FglTFRuntimePathIte
 
 int32 FglTFRuntimeParser::GetJSONArraySizeFromPath(const TArray<FglTFRuntimePathItem>& Path, bool& bFound) const
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_GetJSONArraySizeFromPath, FColor::Cyan);
+
 	int32 ReturnValue = -1;
 	bFound = false;
 

--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -12,6 +12,8 @@
 
 UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(TSharedRef<FJsonObject> JsonMaterialObject, const FglTFRuntimeMaterialsConfig& MaterialsConfig, const bool bUseVertexColors)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadMaterial_Internal, FColor::Cyan);
+
 	FglTFRuntimeMaterial RuntimeMaterial;
 
 	RuntimeMaterial.BaseSpecularFactor = MaterialsConfig.SpecularFactor;
@@ -186,6 +188,8 @@ UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(TSharedRef<FJsonOb
 
 UTexture2D* FglTFRuntimeParser::BuildTexture(UObject* Outer, const TArray<FglTFRuntimeMipMap>& Mips, const TEnumAsByte<TextureCompressionSettings> Compression, const bool sRGB, const FglTFRuntimeMaterialsConfig& MaterialsConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_BuildTexture, FColor::Cyan);
+
 	UTexture2D* Texture = NewObject<UTexture2D>(Outer, NAME_None, RF_Public);
 
 	Texture->PlatformData = new FTexturePlatformData();
@@ -239,6 +243,8 @@ UTexture2D* FglTFRuntimeParser::BuildTexture(UObject* Outer, const TArray<FglTFR
 
 UMaterialInterface* FglTFRuntimeParser::BuildMaterial(const FglTFRuntimeMaterial& RuntimeMaterial, const FglTFRuntimeMaterialsConfig& MaterialsConfig, const bool bUseVertexColors)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_BuildMaterial, FColor::Cyan);
+
 	UMaterialInterface* BaseMaterial = nullptr;
 
 	if (MetallicRoughnessMaterialsMap.Contains(RuntimeMaterial.MaterialType))
@@ -360,6 +366,8 @@ UMaterialInterface* FglTFRuntimeParser::BuildMaterial(const FglTFRuntimeMaterial
 
 UTexture2D* FglTFRuntimeParser::LoadTexture(const int32 TextureIndex, TArray<FglTFRuntimeMipMap>& Mips, const bool sRGB, const FglTFRuntimeMaterialsConfig& MaterialsConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadTexture, FColor::Cyan);
+
 	if (TextureIndex < 0)
 	{
 		return nullptr;
@@ -535,6 +543,8 @@ UTexture2D* FglTFRuntimeParser::LoadTexture(const int32 TextureIndex, TArray<Fgl
 
 UMaterialInterface* FglTFRuntimeParser::LoadMaterial(const int32 Index, const FglTFRuntimeMaterialsConfig& MaterialsConfig, const bool bUseVertexColors)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadMaterial, FColor::Cyan);
+
 	if (Index < 0)
 		return nullptr;
 

--- a/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
@@ -160,6 +160,8 @@ void FglTFRuntimeParser::CopySkeletonRotationsFrom(FReferenceSkeleton& RefSkelet
 
 USkeletalMesh* FglTFRuntimeParser::CreateSkeletalMeshFromLODs(TSharedRef<FglTFRuntimeSkeletalMeshContext, ESPMode::ThreadSafe> SkeletalMeshContext)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_CreateSkeletalMeshFromLODs, FColor::Cyan);
+
 	if (SkeletalMeshContext->SkeletalMeshConfig.OverrideSkinIndex > INDEX_NONE)
 	{
 		SkeletalMeshContext->SkinIndex = SkeletalMeshContext->SkeletalMeshConfig.OverrideSkinIndex;
@@ -650,6 +652,7 @@ USkeletalMesh* FglTFRuntimeParser::CreateSkeletalMeshFromLODs(TSharedRef<FglTFRu
 
 USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTFRuntimeSkeletalMeshContext, ESPMode::ThreadSafe> SkeletalMeshContext)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FinalizeSkeletalMeshWithLODs, FColor::Cyan);
 
 #if !WITH_EDITOR
 	bool bHasMorphTargets = false;
@@ -746,6 +749,7 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 #else
 	if (bHasMorphTargets)
 	{
+		SCOPED_NAMED_EVENT(FglTFRuntimeParser_FinalizeSkeletalMeshWithLODs_InitMorphTargets, FColor::Cyan);
 		SkeletalMeshContext->SkeletalMesh->InitMorphTargets();
 	}
 #endif
@@ -764,6 +768,8 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 #if WITH_EDITOR
 	SkeletalMeshContext->SkeletalMesh->VertexColorGuid = SkeletalMeshContext->SkeletalMesh->bHasVertexColors ? FGuid::NewGuid() : FGuid();
 #endif
+
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FinalizeSkeletalMeshWithLODs_Config, FColor::Cyan);
 
 	if (SkeletalMeshContext->SkeletalMeshConfig.Skeleton)
 	{
@@ -802,6 +808,8 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 			SkeletalMeshContext->SkeletalMesh->Skeleton->Sockets.Add(SkeletalSocket);
 		}
 	}
+
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FinalizeSkeletalMeshWithLODs_PhysicsBodies, FColor::Cyan);
 
 	if (SkeletalMeshContext->SkeletalMeshConfig.PhysicsBodies.Num() > 0)
 	{
@@ -852,6 +860,8 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 		OnSkeletalMeshCreated.Broadcast(SkeletalMeshContext->SkeletalMesh);
 	}
 
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_FinalizeSkeletalMeshWithLODs_SavePackage, FColor::Cyan);
+
 #if WITH_EDITOR
 	if (!SkeletalMeshContext->SkeletalMeshConfig.SaveToPackage.IsEmpty())
 	{
@@ -872,6 +882,7 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 
 USkeletalMesh* FglTFRuntimeParser::LoadSkeletalMesh(const int32 MeshIndex, const int32 SkinIndex, const FglTFRuntimeSkeletalMeshConfig & SkeletalMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeletalMesh, FColor::Cyan);
 
 	// first check cache
 	if (CanReadFromCache(SkeletalMeshConfig.CacheMode) && SkeletalMeshesCache.Contains(MeshIndex))
@@ -929,6 +940,8 @@ void FglTFRuntimeParser::LoadSkeletalMeshAsync(const int32 MeshIndex, const int3
 
 	Async(EAsyncExecution::Thread, [this, SkeletalMeshContext, MeshIndex, AsyncCallback]()
 	{
+		SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeletalMeshAsync, FColor::Cyan);
+
 		FglTFRuntimeSkeletalMeshContextFinalizer AsyncFinalizer(SkeletalMeshContext, AsyncCallback);
 
 		TSharedPtr<FJsonObject> JsonMeshObject = GetJsonObjectFromRootIndex("meshes", MeshIndex);
@@ -957,6 +970,8 @@ void FglTFRuntimeParser::LoadSkeletalMeshAsync(const int32 MeshIndex, const int3
 
 USkeletalMesh* FglTFRuntimeParser::LoadSkeletalMeshLODs(const TArray<int32> MeshIndices, const int32 SkinIndex, const FglTFRuntimeSkeletalMeshConfig & SkeletalMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeletalMeshLODs, FColor::Cyan);
+
 	TArray<FglTFRuntimeLOD> LODs;
 
 	for (const int32 MeshIndex : MeshIndices)
@@ -993,6 +1008,8 @@ USkeletalMesh* FglTFRuntimeParser::LoadSkeletalMeshLODs(const TArray<int32> Mesh
 
 USkeletalMesh* FglTFRuntimeParser::LoadSkeletalMeshRecursive(const FString & NodeName, const int32 SkinIndex, const TArray<FString>&ExcludeNodes, const FglTFRuntimeSkeletalMeshConfig & SkeletalMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeletalMeshRecursive, FColor::Cyan);
+
 	FglTFRuntimeNode Node;
 	TArray<FglTFRuntimeNode> Nodes;
 
@@ -1133,6 +1150,8 @@ void FglTFRuntimeParser::LoadSkeletalMeshRecursiveAsync(const FString & NodeName
 
 	Async(EAsyncExecution::Thread, [this, SkeletalMeshContext, ExcludeNodes, NodeName, SkinIndex, AsyncCallback]()
 	{
+		SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeletalMeshRecursiveAsync, FColor::Cyan);
+
 		FglTFRuntimeSkeletalMeshContextFinalizer AsyncFinalizer(SkeletalMeshContext, AsyncCallback);
 
 		FglTFRuntimeNode Node;
@@ -1266,6 +1285,8 @@ void FglTFRuntimeParser::LoadSkeletalMeshRecursiveAsync(const FString & NodeName
 
 UAnimSequence* FglTFRuntimeParser::LoadSkeletalAnimationByName(USkeletalMesh * SkeletalMesh, const FString AnimationName, const FglTFRuntimeSkeletalAnimationConfig & SkeletalAnimationConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeletalAnimationByName, FColor::Cyan);
+
 	if (!SkeletalMesh)
 	{
 		return nullptr;
@@ -1301,6 +1322,7 @@ UAnimSequence* FglTFRuntimeParser::LoadSkeletalAnimationByName(USkeletalMesh * S
 
 UAnimSequence* FglTFRuntimeParser::LoadNodeSkeletalAnimation(USkeletalMesh * SkeletalMesh, const int32 NodeIndex, const FglTFRuntimeSkeletalAnimationConfig & SkeletalAnimationConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadNodeSkeletalAnimation, FColor::Cyan);
 
 	if (!SkeletalMesh)
 	{
@@ -1383,6 +1405,8 @@ UAnimSequence* FglTFRuntimeParser::LoadNodeSkeletalAnimation(USkeletalMesh * Ske
 
 UAnimSequence* FglTFRuntimeParser::LoadSkeletalAnimation(USkeletalMesh * SkeletalMesh, const int32 AnimationIndex, const FglTFRuntimeSkeletalAnimationConfig & SkeletalAnimationConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeletalAnimation, FColor::Cyan);
+
 	if (!SkeletalMesh)
 	{
 		return nullptr;
@@ -1606,6 +1630,8 @@ UAnimSequence* FglTFRuntimeParser::LoadSkeletalAnimation(USkeletalMesh * Skeleta
 
 bool FglTFRuntimeParser::LoadSkeletalAnimation_Internal(TSharedRef<FJsonObject> JsonAnimationObject, TMap<FString, FRawAnimSequenceTrack>&Tracks, TMap<FName, TArray<TPair<float, float>>>&MorphTargetCurves, float& Duration, const FglTFRuntimeSkeletalAnimationConfig & SkeletalAnimationConfig, TFunctionRef<bool(const FglTFRuntimeNode& Node)> Filter)
 {
+
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadSkeletalAnimation_Internal, FColor::Cyan);
 
 	auto Callback = [&](const FglTFRuntimeNode& Node, const FString& Path, const TArray<float> Timeline, const TArray<FVector4> Values)
 	{

--- a/Source/glTFRuntime/Private/glTFRuntimeParserStaticMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserStaticMeshes.cpp
@@ -11,6 +11,7 @@
 
 UStaticMesh* FglTFRuntimeParser::LoadStaticMesh_Internal(TArray<TSharedRef<FJsonObject>> JsonMeshObjects, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig, const TMap<TSharedRef<FJsonObject>, TArray<FglTFRuntimePrimitive>>& PrimitivesCache)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadStaticMesh_Internal, FColor::Cyan);
 
 	UStaticMesh* StaticMesh = NewObject<UStaticMesh>(StaticMeshConfig.Outer ? StaticMeshConfig.Outer : GetTransientPackage(), NAME_None, RF_Public);
 	StaticMesh->bAllowCPUAccess = StaticMeshConfig.bAllowCPUAccess;
@@ -358,6 +359,8 @@ UStaticMesh* FglTFRuntimeParser::LoadStaticMesh_Internal(TArray<TSharedRef<FJson
 
 bool FglTFRuntimeParser::LoadStaticMeshes(TArray<UStaticMesh*>& StaticMeshes, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadStaticMeshes, FColor::Cyan);
+
 	const TArray<TSharedPtr<FJsonValue>>* JsonMeshes;
 	// no meshes ?
 	if (!Root->TryGetArrayField("meshes", JsonMeshes))
@@ -380,6 +383,7 @@ bool FglTFRuntimeParser::LoadStaticMeshes(TArray<UStaticMesh*>& StaticMeshes, co
 
 UStaticMesh* FglTFRuntimeParser::LoadStaticMesh(const int32 MeshIndex, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadStaticMesh, FColor::Cyan);
 
 	TSharedPtr<FJsonObject> JsonMeshObject = GetJsonObjectFromRootIndex("meshes", MeshIndex);
 	if (!JsonMeshObject)
@@ -412,6 +416,8 @@ UStaticMesh* FglTFRuntimeParser::LoadStaticMesh(const int32 MeshIndex, const Fgl
 
 TArray<UStaticMesh*> FglTFRuntimeParser::LoadStaticMeshesFromPrimitives(const int32 MeshIndex, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadStaticMeshesFromPrimitives, FColor::Cyan);
+
 	TArray<UStaticMesh*> StaticMeshes;
 
 	TSharedPtr<FJsonObject> JsonMeshObject = GetJsonObjectFromRootIndex("meshes", MeshIndex);
@@ -450,6 +456,8 @@ TArray<UStaticMesh*> FglTFRuntimeParser::LoadStaticMeshesFromPrimitives(const in
 
 UStaticMesh* FglTFRuntimeParser::LoadStaticMeshLODs(const TArray<int32> MeshIndices, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadStaticMeshLODs, FColor::Cyan);
+
 	TArray<TSharedRef<FJsonObject>> JsonMeshObjects;
 
 	for (const int32 MeshIndex : MeshIndices)
@@ -469,6 +477,8 @@ UStaticMesh* FglTFRuntimeParser::LoadStaticMeshLODs(const TArray<int32> MeshIndi
 
 bool FglTFRuntimeParser::LoadStaticMeshIntoProceduralMeshComponent(const int32 MeshIndex, UProceduralMeshComponent* ProceduralMeshComponent, const FglTFRuntimeProceduralMeshConfig& ProceduralMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadStaticMeshIntoProceduralMeshComponent, FColor::Cyan);
+
 	if (!ProceduralMeshComponent)
 	{
 		return false;
@@ -521,6 +531,8 @@ bool FglTFRuntimeParser::LoadStaticMeshIntoProceduralMeshComponent(const int32 M
 
 UStaticMesh* FglTFRuntimeParser::LoadStaticMeshByName(const FString Name, const FglTFRuntimeStaticMeshConfig& StaticMeshConfig)
 {
+	SCOPED_NAMED_EVENT(FglTFRuntimeParser_LoadStaticMeshByName, FColor::Cyan);
+
 	const TArray<TSharedPtr<FJsonValue>>* JsonMeshes;
 	if (!Root->TryGetArrayField("meshes", JsonMeshes))
 	{


### PR DESCRIPTION
Gathering CPU profiling data inside of Unreal Insights requires sprinkling `SCOPED_NAMED_EVENT ` throughout the codebase in areas that you want to measure. This PR adds these macros to areas that I thought would make the most sense.

Now we can grab some great performance details like this:
![image](https://user-images.githubusercontent.com/700435/129250082-5879457f-ea3d-40fb-9fd3-b31653c2be39.png)
