### PR TITLE
Add Android to plugin WhitelistPlatforms

### DIFF
--- a/glTFRuntime.uplugin
+++ b/glTFRuntime.uplugin
@@ -19,7 +19,7 @@
       "Name": "glTFRuntime",
       "Type": "Runtime",
       "LoadingPhase": "Default",
-      "WhitelistPlatforms": [ "Win64", "Mac", "Linux" ]
+      "WhitelistPlatforms": [ "Win64", "Mac", "Linux", "Android" ]
     },
     {
       "Name": "glTFRuntimeEditor",


### PR DESCRIPTION
From my testing the plugin seems to function perfectly fine on Android. Not including Android in the WhitelistPlatforms prevents access to it unnecessarily.