### PR TITLE
Update glTFRuntimeParserMaterials.cpp

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -374,7 +374,7 @@ UMaterialInterface* FglTFRuntimeParser::BuildMaterial(const int32 Index, const F
 
 	Material->SetScalarParameterValue("bUseVertexColors", (bUseVertexColors && !MaterialsConfig.bDisableVertexColors) ? 1.0f : 0.0f);
 
-	for (const TPair<FString, float> Pair : MaterialsConfig.ParamsMultiplier)
+	for (const TPair<FString, float>& Pair : MaterialsConfig.ParamsMultiplier)
 	{
 		float ScalarValue = 0;
 		FLinearColor VectorValue = FLinearColor::Black;


### PR DESCRIPTION
Fix linux compilation
glTFRuntimeParserMaterials.cpp:377:35: error: loop variable 'Pair' creates a copy from type 'const TPair<FString, float>' (aka 'const TTuple<FString, float>') [-Werror,-Wrange-loop-construct]