### PR TITLE
Async Center Pivot and Complex Collision Fixes

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeAssetActorAsync.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAssetActorAsync.cpp
@@ -114,6 +114,10 @@ void AglTFRuntimeAssetActorAsync::LoadNextMeshAsync()
 	if (UStaticMeshComponent* StaticMeshComponent = Cast<UStaticMeshComponent>(It->Key))
 	{
 		CurrentPrimitiveComponent = StaticMeshComponent;
+		if (StaticMeshConfig.Outer == nullptr)
+		{
+			StaticMeshConfig.Outer = StaticMeshComponent;
+		}
 		FglTFRuntimeStaticMeshAsync Delegate;
 		Delegate.BindDynamic(this, &AglTFRuntimeAssetActorAsync::LoadStaticMeshAsync);
 		Asset->LoadStaticMeshAsync(It->Value.MeshIndex, Delegate, StaticMeshConfig);

--- a/Source/glTFRuntime/Private/glTFRuntimeAssetActorAsync.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAssetActorAsync.cpp
@@ -132,6 +132,24 @@ void AglTFRuntimeAssetActorAsync::LoadStaticMeshAsync(UStaticMesh* StaticMesh)
 	if (UStaticMeshComponent* StaticMeshComponent = Cast<UStaticMeshComponent>(CurrentPrimitiveComponent))
 	{
 		StaticMeshComponent->SetStaticMesh(StaticMesh);
+
+		if (StaticMeshConfig.Outer == nullptr)
+		{
+			StaticMeshConfig.Outer = StaticMeshComponent;
+		}
+		if (StaticMesh && !StaticMeshConfig.ExportOriginalPivotToSocket.IsEmpty())
+		{
+			UStaticMeshSocket* DeltaSocket = StaticMesh->FindSocket(FName(StaticMeshConfig.ExportOriginalPivotToSocket));
+			if (DeltaSocket)
+			{
+				FTransform NewTransform = StaticMeshComponent->GetRelativeTransform();
+				FVector DeltaLocation = -DeltaSocket->RelativeLocation * NewTransform.GetScale3D();
+				DeltaLocation = NewTransform.GetRotation().RotateVector(DeltaLocation);
+				NewTransform.AddToTranslation(DeltaLocation);
+				StaticMeshComponent->SetRelativeTransform(NewTransform);
+			}
+		}
+
 	}
 
 	MeshesToLoad.Remove(CurrentPrimitiveComponent);


### PR DESCRIPTION
1- I copied center pivot function from gLTFRuntimeAssetActor

2- I wrote it in LoadStaticMeshAsync
Because ProcessNode gives 'initializing': cannot convert from 'void' to 'UStaticMesh * error and we already have a StaticMesh load function

3- I deleted UStaticMesh* StaticMesh line because parent void function already have it

4- (Thanks to Glowing Rabbit from our discord channel) he added StaticMeshConfig.outer = StaticMeshComponent to LoadNextMeshAsync