### PR TITLE
Fixed header issue for AnimCurveCompressionCodec

### DIFF
--- a/Source/glTFRuntime/Private/glTFAnimCurveCompressionCodec.cpp
+++ b/Source/glTFRuntime/Private/glTFAnimCurveCompressionCodec.cpp
@@ -3,6 +3,8 @@
 
 #include "glTFAnimCurveCompressionCodec.h"
 
+#include "Animation/AnimSequence.h"
+
 void UglTFAnimCurveCompressionCodec::DecompressCurves(const FCompressedAnimSequence& AnimSeq, FBlendedCurve& Curves, float CurrentTime) const
 {
 	if (!AnimSequence)


### PR DESCRIPTION
Added AnimSequence header the to fix the android compilation issue in AnimCurveCompressionCodec