### PR TITLE
Include fixes for UE5.2

### DIFF
--- a/Source/glTFRuntime/Private/glTFAnimBoneCompressionCodec.cpp
+++ b/Source/glTFRuntime/Private/glTFAnimBoneCompressionCodec.cpp
@@ -2,6 +2,7 @@
 
 
 #include "glTFAnimBoneCompressionCodec.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 void UglTFAnimBoneCompressionCodec::DecompressBone(FAnimSequenceDecompressionContext& DecompContext, int32 TrackIndex, FTransform& OutAtom) const
 {

--- a/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
@@ -2,6 +2,7 @@
 
 #include "glTFRuntimeAsset.h"
 #include "Animation/AnimSequence.h"
+#include "Engine/World.h"
 
 #define GLTF_CHECK_ERROR_MESSAGE() UE_LOG(LogGLTFRuntime, Error, TEXT("No glTF Asset loaded."))
 

--- a/Source/glTFRuntime/Private/glTFRuntimeAssetActorAsync.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAssetActorAsync.cpp
@@ -3,6 +3,7 @@
 
 #include "glTFRuntimeAssetActorAsync.h"
 #include "Components/SkeletalMeshComponent.h"
+#include "Components/StaticMeshComponent.h"
 #include "Engine/StaticMeshSocket.h"
 
 // Sets default values

--- a/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
@@ -5,14 +5,13 @@
 #include "Serialization/JsonSerializer.h"
 #include "Animation/Skeleton.h"
 #include "Materials/Material.h"
-// #include "Runtime/Launch/Resources/Version.h"
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1
 #include "MaterialDomain.h"
+#include "RenderMath.h"
 #endif
 #include "Misc/Base64.h"
 #include "Misc/Compression.h"
 #include "Misc/Paths.h"
-#include "RenderMath.h"
 #include "Engine/Texture2D.h"
 #include "Interfaces/IPluginManager.h"
 

--- a/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
@@ -5,12 +5,15 @@
 #include "Serialization/JsonSerializer.h"
 #include "Animation/Skeleton.h"
 #include "Materials/Material.h"
-#include "Runtime/Launch/Resources/Version.h"
+// #include "Runtime/Launch/Resources/Version.h"
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1
 #include "MaterialDomain.h"
 #endif
 #include "Misc/Base64.h"
 #include "Misc/Compression.h"
+#include "Misc/Paths.h"
+#include "RenderMath.h"
+#include "Engine/Texture2D.h"
 #include "Interfaces/IPluginManager.h"
 
 DEFINE_LOG_CATEGORY(LogGLTFRuntime);

--- a/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
@@ -5,6 +5,7 @@
 #include "Serialization/JsonSerializer.h"
 #include "Animation/Skeleton.h"
 #include "Materials/Material.h"
+#include "Runtime/Launch/Resources/Version.h"
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1
 #include "MaterialDomain.h"
 #endif

--- a/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
@@ -5,6 +5,9 @@
 #include "Serialization/JsonSerializer.h"
 #include "Animation/Skeleton.h"
 #include "Materials/Material.h"
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1
+#include "MaterialDomain.h"
+#endif
 #include "Misc/Base64.h"
 #include "Misc/Compression.h"
 #include "Interfaces/IPluginManager.h"

--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -6,6 +6,9 @@
 #include "ImageUtils.h"
 #include "Misc/FileHelper.h"
 #include "Materials/MaterialInstanceDynamic.h"
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1
+#include "MaterialDomain.h"
+#endif
 #include "Math/UnrealMathUtility.h"
 #include "Modules/ModuleManager.h"
 

--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -11,6 +11,7 @@
 #endif
 #include "Math/UnrealMathUtility.h"
 #include "Modules/ModuleManager.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 
 UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(const int32 Index, const FString& MaterialName, TSharedRef<FJsonObject> JsonMaterialObject, const FglTFRuntimeMaterialsConfig& MaterialsConfig, const bool bUseVertexColors)

--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -5,14 +5,15 @@
 #include "IImageWrapper.h"
 #include "ImageUtils.h"
 #include "Misc/FileHelper.h"
+#include "Materials/Material.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1
 #include "MaterialDomain.h"
 #endif
 #include "Math/UnrealMathUtility.h"
 #include "Modules/ModuleManager.h"
-#include "Runtime/Launch/Resources/Version.h"
-
+#include "Engine/Texture2D.h"
+#include "TextureResource.h"
 
 UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(const int32 Index, const FString& MaterialName, TSharedRef<FJsonObject> JsonMaterialObject, const FglTFRuntimeMaterialsConfig& MaterialsConfig, const bool bUseVertexColors)
 {

--- a/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2022, Roberto De Ioris.
 
 #include "glTFRuntimeParser.h"
+#include "Animation/Skeleton.h"
 #if ENGINE_MAJOR_VERSION > 4
 #include "Animation/AnimData/AnimDataModel.h"
 #include "Animation/AnimData/IAnimationDataController.h"

--- a/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
@@ -24,6 +24,9 @@
 #endif
 #endif
 #include "Engine/SkeletalMeshSocket.h"
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 1
+#include "Engine/SkinnedAssetCommon.h"
+#endif
 #include "glTFAnimBoneCompressionCodec.h"
 #include "glTFAnimCurveCompressionCodec.h"
 #include "Model.h"

--- a/Source/glTFRuntime/Private/glTFRuntimeParserStaticMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserStaticMeshes.cpp
@@ -3,14 +3,15 @@
 #include "glTFRuntimeParser.h"
 #include "Async/Async.h"
 #include "MeshDescription.h"
+#include "StaticMeshResources.h"
 #include "StaticMeshAttributes.h"
 #include "StaticMeshOperations.h"
+#include "Engine/World.h"
 #include "Engine/StaticMeshSocket.h"
 #if WITH_EDITOR
 #include "Editor/EditorEngine.h"
 #endif
 #include "PhysicsEngine/BodySetup.h"
-#include "Runtime/Launch/Resources/Version.h"
 
 FglTFRuntimeStaticMeshContext::FglTFRuntimeStaticMeshContext(TSharedRef<FglTFRuntimeParser> InParser, const FglTFRuntimeStaticMeshConfig& InStaticMeshConfig) :
 	Parser(InParser),

--- a/Source/glTFRuntime/Private/glTFRuntimeParserStaticMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserStaticMeshes.cpp
@@ -10,6 +10,7 @@
 #include "Editor/EditorEngine.h"
 #endif
 #include "PhysicsEngine/BodySetup.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 FglTFRuntimeStaticMeshContext::FglTFRuntimeStaticMeshContext(TSharedRef<FglTFRuntimeParser> InParser, const FglTFRuntimeStaticMeshConfig& InStaticMeshConfig) :
 	Parser(InParser),

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -8,6 +8,8 @@
 #include "Engine/StaticMesh.h"
 #include "Engine/SkeletalMesh.h"
 #include "Engine/Texture.h"
+#include "Engine/DataAsset.h"
+#include "Animation/AnimEnums.h"
 #include "Camera/CameraComponent.h"
 #include "Components/AudioComponent.h"
 #include "glTFRuntimeAnimationCurve.h"

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -1116,7 +1116,7 @@ struct FglTFRuntimeSkeletalMeshContext : public FGCObject
 	FglTFRuntimeSkeletalMeshContext(TSharedRef<FglTFRuntimeParser> InParser, const FglTFRuntimeSkeletalMeshConfig& InSkeletalMeshConfig) : Parser(InParser), SkeletalMeshConfig(InSkeletalMeshConfig)
 	{
 		EObjectFlags Flags = RF_Public;
-		UObject* Outer = InSkeletalMeshConfig.Outer ? InSkeletalMeshConfig.Outer : GetTransientPackage();
+		UObject* Outer = InSkeletalMeshConfig.Outer ? InSkeletalMeshConfig.Outer : Cast<UObject>(GetTransientPackage());
 #if WITH_EDITOR
 		if (!InSkeletalMeshConfig.SaveToPackage.IsEmpty())
 		{

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -1565,7 +1565,7 @@ public:
 	bool GetBooleanFromExtras(const FString& Key, bool& Value) const;
 
 	bool LoadAudioEmitter(const int32 EmitterIndex, FglTFRuntimeAudioEmitter& Emitter);
-	ULightComponent* LoadPunctualLight(const int32 PunctualLightIndex, AActor* Actor, const FglTFRuntimeLightConfig& LightConfig);
+	class ULightComponent* LoadPunctualLight(const int32 PunctualLightIndex, AActor* Actor, const FglTFRuntimeLightConfig& LightConfig);
 
 	TArray<FString> ExtensionsUsed;
 	TArray<FString> ExtensionsRequired;

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "EngineMinimal.h"
 #include "CoreMinimal.h"
 #include "Dom/JsonValue.h"
 #include "Dom/JsonObject.h"
@@ -15,6 +14,7 @@
 #include "Components/AudioComponent.h"
 #include "glTFRuntimeAnimationCurve.h"
 #include "ProceduralMeshComponent.h"
+#include "UObject/StructOnScope.h"
 #if WITH_EDITOR
 #include "Rendering/SkeletalMeshLODImporterData.h"
 #endif

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "Dom/JsonValue.h"
 #include "Dom/JsonObject.h"
 #include "Engine/StaticMesh.h"

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -14,7 +14,7 @@
 #include "Components/AudioComponent.h"
 #include "glTFRuntimeAnimationCurve.h"
 #include "ProceduralMeshComponent.h"
-#include "UObject/StructOnScope.h"
+#include "UObject/Package.h"
 #if WITH_EDITOR
 #include "Rendering/SkeletalMeshLODImporterData.h"
 #endif

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "EngineMinimal.h"
 #include "CoreMinimal.h"
 #include "Dom/JsonValue.h"
 #include "Dom/JsonObject.h"

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -7,6 +7,7 @@
 #include "Dom/JsonObject.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/SkeletalMesh.h"
+#include "Engine/Texture.h"
 #include "Camera/CameraComponent.h"
 #include "Components/AudioComponent.h"
 #include "glTFRuntimeAnimationCurve.h"

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -9,7 +9,7 @@
 #include "Engine/SkeletalMesh.h"
 #include "Engine/Texture.h"
 #include "Engine/DataAsset.h"
-#include "Animation/AnimEnums.h"
+#include "Animation/AnimTypes.h"
 #include "Camera/CameraComponent.h"
 #include "Components/AudioComponent.h"
 #include "glTFRuntimeAnimationCurve.h"

--- a/Source/glTFRuntimeEditor/Private/SkeletonExporterGLTF.cpp
+++ b/Source/glTFRuntimeEditor/Private/SkeletonExporterGLTF.cpp
@@ -2,6 +2,7 @@
 
 
 #include "SkeletonExporterGLTF.h"
+#include "Misc/Base64.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
 


### PR DESCRIPTION
UE5.2 introduced some changes to the headers.
The change allows building the plugin for UE5.2.