### PR TITLE
Fix GetAccessor() call returning 0 stride when accessor is loaded from cache

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
@@ -3079,6 +3079,7 @@ bool FglTFRuntimeParser::GetAccessor(const int32 Index, int64& ComponentType, in
 
 	if (SparseAccessorsCache.Contains(Index))
 	{
+		Stride = SparseAccessorsStridesCache[Index];
 		Blob.Data = SparseAccessorsCache[Index].GetData();
 		Blob.Num = SparseAccessorsCache[Index].Num();
 		return true;
@@ -3199,6 +3200,7 @@ bool FglTFRuntimeParser::GetAccessor(const int32 Index, int64& ComponentType, in
 	Stride = SparseBufferViewValuesStride;
 
 	SparseAccessorsCache.Add(Index);
+	SparseAccessorsStridesCache.Add(Index, Stride);
 	TArray64<uint8>& SparseData = SparseAccessorsCache[Index];
 	SparseData.Append(Blob.Data, Blob.Num);
 

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -2020,6 +2020,7 @@ protected:
 
 	TArray64<uint8> ZeroBuffer;
 	TMap<int32, TArray64<uint8>> SparseAccessorsCache;
+	TMap<int32, int64> SparseAccessorsStridesCache;
 
 	TMap<int64, TMap<FString, FglTFRuntimeBlob>> AdditionalBufferViewsCache;
 	TArray<TArray64<uint8>> AdditionalBufferViewsData;


### PR DESCRIPTION
Currently if a sparse accessor is loaded a second time, it is loaded from SparseAccessorsStridesCache but the stride computation is mistakenly skipped. This commit store the stride computed into another cache and load its value on the cached load.