### PR TITLE
Disable KHR_materials_transparent when transmissionFactor = 0

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -222,11 +222,11 @@ UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(const int32 Index,
 		{
 			if ((*JsonMaterialTransmission)->TryGetNumberField("transmissionFactor", RuntimeMaterial.TransmissionFactor))
 			{
-				RuntimeMaterial.bHasTransmissionFactor = true;
+				RuntimeMaterial.bHasTransmissionFactor = (RuntimeMaterial.TransmissionFactor > 0.0);
 			}
 			GetMaterialTexture(JsonMaterialTransmission->ToSharedRef(), "transmissionTexture", false, RuntimeMaterial.TransmissionTextureCache, RuntimeMaterial.TransmissionTextureMips, RuntimeMaterial.TransmissionTransform, RuntimeMaterial.TransmissionSampler, false);
 
-			RuntimeMaterial.bKHR_materials_transmission = true;
+			RuntimeMaterial.bKHR_materials_transmission = (RuntimeMaterial.TransmissionFactor > 0.0);
 		}
 
 		// KHR_materials_unlit 


### PR DESCRIPTION
Some glTFs have the KHR_materials_transmission extension with `transmissionFactor` set to the default of `0.0`. This means that the material effectively has no transmission at all, even if a transmission texture is specified (as `transmissionFactor acts as multiplier on the texture values)