### PR TITLE
Set bForceOpaqueOutput to false

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -976,7 +976,7 @@ bool FglTFRuntimeParser::LoadBlobToMips(const int32 TextureIndex, TSharedRef<FJs
 				{
 					TArray64<FColor> ResizedMipData;
 					ResizedMipData.AddUninitialized(MipWidth * MipHeight);
-					FImageUtils::ImageResize(Width, Height, UncompressedColors, MipWidth, MipHeight, ResizedMipData, sRGB);
+					FImageUtils::ImageResize(Width, Height, UncompressedColors, MipWidth, MipHeight, ResizedMipData, sRGB, false);
 					for (FColor& Color : ResizedMipData)
 					{
 						MipMap.Pixels.Add(Color.B);

--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -976,7 +976,11 @@ bool FglTFRuntimeParser::LoadBlobToMips(const int32 TextureIndex, TSharedRef<FJs
 				{
 					TArray64<FColor> ResizedMipData;
 					ResizedMipData.AddUninitialized(MipWidth * MipHeight);
+#if ENGINE_MAJOR_VERSION >= 5
 					FImageUtils::ImageResize(Width, Height, UncompressedColors, MipWidth, MipHeight, ResizedMipData, sRGB, false);
+#else
+					FImageUtils::ImageResize(Width, Height, UncompressedColors, MipWidth, MipHeight, ResizedMipData, sRGB);
+#endif
 					for (FColor& Color : ResizedMipData)
 					{
 						MipMap.Pixels.Add(Color.B);


### PR DESCRIPTION
If a texture contains transparency any generated mips are forced to be opaque. This sets the value to false, instead of the default value of true.