### PR TITLE
Animation curve loop custom start time

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeAnimationCurve.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAnimationCurve.cpp
@@ -9,6 +9,11 @@ UglTFRuntimeAnimationCurve::UglTFRuntimeAnimationCurve()
 	glTFCurveAnimationDuration = 0;
 }
 
+void UglTFRuntimeAnimationCurve::SetglTFLoopStartTime(float StartTimeInput)
+{
+	glTFLoopStartTime = StartTimeInput < 0 ? glTFCurveAnimationDuration : StartTimeInput;
+}
+
 FTransform UglTFRuntimeAnimationCurve::GetTransformValue(float InTime) const
 {
 	FVector Location;

--- a/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
@@ -430,6 +430,14 @@ void AglTFRuntimeAssetActor::SetCurveAnimationByName(const FString& CurveAnimati
 
 }
 
+void AglTFRuntimeAssetActor::SetAllLoopTimes(float LoopTime)
+{
+	for(TPair<USceneComponent*, UglTFRuntimeAnimationCurve*>& Pair : CurveBasedAnimations)
+	{
+		Pair.Value->SetglTFLoopStartTime(LoopTime);
+	}
+}
+
 // Called every frame
 void AglTFRuntimeAssetActor::Tick(float DeltaTime)
 {
@@ -449,8 +457,8 @@ void AglTFRuntimeAssetActor::Tick(float DeltaTime)
 		float CurrentTime = CurveBasedAnimationsTimeTracker[Pair.Key];
 		if (CurrentTime > Pair.Value->glTFCurveAnimationDuration)
 		{
-			CurveBasedAnimationsTimeTracker[Pair.Key] = 0;
-			CurrentTime = 0;
+			CurveBasedAnimationsTimeTracker[Pair.Key] = Pair.Value->glTFLoopStartTime;
+			CurrentTime = Pair.Value->glTFLoopStartTime;
 		}
 
 		if (CurrentTime >= MinTime)

--- a/Source/glTFRuntime/Public/glTFRuntimeAnimationCurve.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeAnimationCurve.h
@@ -50,6 +50,13 @@ public:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "glTFRuntime|Curves")
     float glTFCurveAnimationDuration;
 
+	//Sets which time looping will start from. setting to 0 will cause it to do a full loop. setting to -1 will cause it to stick on the last frame. defaults to 0
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, BlueprintSetter=SetglTFLoopStartTime, Category = "glTFRuntime|Curves")
+	float glTFLoopStartTime = 0;
+
+	UFUNCTION(BlueprintCallable)
+	void SetglTFLoopStartTime(float StartTimeInput);
+	
     FMatrix BasisMatrix;
 
     /** Evaluate this float curve at the specified time */

--- a/Source/glTFRuntime/Public/glTFRuntimeAssetActor.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeAssetActor.h
@@ -75,6 +75,14 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "glTFRuntime")
 	void SetCurveAnimationByName(const FString& CurveAnimationName);
 
+	/**
+	 *Sets the time in all animations curves which animations that reach their end will start from.
+	 *LoopTime is the Timestamp at which the loops should occur
+	 *These properties can be set individually through the CurveBasedAnimations values
+	 */
+	UFUNCTION(BlueprintCallable, Category = "glTFRuntime",meta=(DisplayName="Set Loop Start Time"))
+	void SetAllLoopTimes(float LoopTime);
+	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Meta = (ExposeOnSpawn = true), Category = "glTFRuntime")
 	bool bAllowNodeAnimations;
 


### PR DESCRIPTION
Added the ability for users to set a specific time animations will loop on the animation curve, since this doesn't seem to be that easy to do with the current setup. To be clear, the animation will play from the start to the finish the first runthrough, but when reaching its end, the curve time will be reset to the specified timestamp. This property defaults to 0, maintaining the way the animation code currently works, but can also be set to -1 to automatically set the value to the end time, which means it stays on the final frame of the animation. This variable can be set for individual curves or set for the entire set.

This information is set via code or blueprints, not loaded from the GLB itself, but if anyone else has more knowledge of GLB files, they could probably set this up better.