### PR TITLE
Mip map transparency fix

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -1311,7 +1311,11 @@ bool FglTFRuntimeParser::LoadBlobToMips(const int32 TextureIndex, TSharedRef<FJs
 				{
 					TArray64<FColor> ResizedMipData;
 					ResizedMipData.AddUninitialized(MipWidth * MipHeight);
+#if ENGINE_MAJOR_VERSION >= 5
+					FImageUtils::ImageResize(Width, Height, UncompressedColors, MipWidth, MipHeight, ResizedMipData, sRGB, false);
+#else
 					FImageUtils::ImageResize(Width, Height, UncompressedColors, MipWidth, MipHeight, ResizedMipData, sRGB);
+#endif
 					for (FColor& Color : ResizedMipData)
 					{
 						MipMap.Pixels.Add(Color.B);


### PR DESCRIPTION
This pull request adds an argument to the image resize function to allow for creating translucent mip maps. 

Super useful add-on, thanks!