### PR TITLE
Fix two sided translucent materials using basic translucent material

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -75,7 +75,7 @@ UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(const int32 Index,
 	{
 		RuntimeMaterial.MaterialType = EglTFRuntimeMaterialType::TwoSidedTranslucent;
 	}
-	if (RuntimeMaterial.bMasked && RuntimeMaterial.bTwoSided)
+	else if (RuntimeMaterial.bMasked && RuntimeMaterial.bTwoSided)
 	{
 		RuntimeMaterial.MaterialType = EglTFRuntimeMaterialType::TwoSidedMasked;
 	}


### PR DESCRIPTION
Previously, two sided translucent materials would fall through to the regular translucent material case. 