### PR TITLE
Added support for KHR_materials_iridescence params

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -329,6 +329,37 @@ UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(const int32 Index,
 			GetMaterialTexture(JsonMaterialSheen->ToSharedRef(), "sheenRoughnessTexture", false, RuntimeMaterial.SheenRoughnessTextureCache, RuntimeMaterial.SheenRoughnessTextureMips, RuntimeMaterial.SheenRoughnessTextureTransform, RuntimeMaterial.SheenRoughnessTextureSampler, false);
 			RuntimeMaterial.bKHR_materials_sheen = true;
 		}
+
+		// KHR_materials_iridescence
+		const TSharedPtr<FJsonObject>* JsonMaterialIridescence;
+		if ((*JsonExtensions)->TryGetObjectField(TEXT("KHR_materials_iridescence"), JsonMaterialIridescence))
+		{
+			if (!(*JsonMaterialIridescence)->TryGetNumberField(TEXT("iridescenceFactor"), RuntimeMaterial.IridescenceFactor))
+			{
+				RuntimeMaterial.IridescenceFactor = 0;
+			}
+
+			if (!(*JsonMaterialIridescence)->TryGetNumberField(TEXT("iridescenceIor"), RuntimeMaterial.IridescenceIor))
+			{
+				RuntimeMaterial.IridescenceIor = 1.3;
+			}
+
+			if (!(*JsonMaterialIridescence)->TryGetNumberField(TEXT("iridescenceThicknessMinimum"), RuntimeMaterial.IridescenceThicknessMinimum))
+			{
+				RuntimeMaterial.IridescenceThicknessMinimum = 200;
+			}
+
+			if (!(*JsonMaterialIridescence)->TryGetNumberField(TEXT("iridescenceThicknessMaximum"), RuntimeMaterial.IridescenceThicknessMaximum))
+			{
+				RuntimeMaterial.IridescenceThicknessMaximum = 400;
+			}
+
+			GetMaterialTexture(JsonMaterialIridescence->ToSharedRef(), "iridescenceTexture", false, RuntimeMaterial.IridescenceTextureCache, RuntimeMaterial.IridescenceTextureMips, RuntimeMaterial.IridescenceTextureTransform, RuntimeMaterial.IridescenceTextureSampler, false);
+			GetMaterialTexture(JsonMaterialIridescence->ToSharedRef(), "iridescenceThicknessTexture", false, RuntimeMaterial.IridescenceThicknessTextureCache, RuntimeMaterial.IridescenceThicknessTextureMips, RuntimeMaterial.IridescenceThicknessTextureTransform, RuntimeMaterial.IridescenceThicknessTextureSampler, false);
+
+			RuntimeMaterial.bKHR_materials_iridescence = true;
+		}
+
 	}
 
 	if (IsInGameThread())
@@ -954,6 +985,23 @@ UMaterialInterface* FglTFRuntimeParser::BuildMaterial(const int32 Index, const F
 			RuntimeMaterial.SheenRoughnessTextureSampler,
 			"sheenRoughness", RuntimeMaterial.SheenRoughnessTextureTransform,
 			TextureCompressionSettings::TC_Default, false);
+	}
+
+	ApplyMaterialFloatFactor(RuntimeMaterial.bKHR_materials_iridescence, "iridescenceFactor", RuntimeMaterial.IridescenceFactor);
+	ApplyMaterialFloatFactor(RuntimeMaterial.bKHR_materials_iridescence, "iridescenceIor", RuntimeMaterial.IridescenceIor);
+	ApplyMaterialFloatFactor(RuntimeMaterial.bKHR_materials_iridescence, "iridescenceThicknessMaximum", RuntimeMaterial.IridescenceThicknessMaximum);
+	ApplyMaterialFloatFactor(RuntimeMaterial.bKHR_materials_iridescence, "iridescenceThicknessMinimum", RuntimeMaterial.IridescenceThicknessMinimum);
+	if (RuntimeMaterial.bKHR_materials_iridescence)
+	{
+		ApplyMaterialTexture("iridescenceTexture", RuntimeMaterial.IridescenceTextureCache, RuntimeMaterial.IridescenceTextureMips,
+			RuntimeMaterial.IridescenceTextureSampler,
+			"iridescence", RuntimeMaterial.IridescenceTextureTransform,
+			TextureCompressionSettings::TC_Default, true);
+
+		ApplyMaterialTexture("iridescenceThicknessTexture", RuntimeMaterial.IridescenceThicknessTextureCache, RuntimeMaterial.IridescenceThicknessTextureMips,
+			RuntimeMaterial.IridescenceThicknessTextureSampler,
+			"iridescenceThickness", RuntimeMaterial.IridescenceThicknessTextureTransform,
+			TextureCompressionSettings::TC_Default, true);
 	}
 
 	ApplyMaterialFloatFactor(RuntimeMaterial.bKHR_materials_emissive_strength, "emissiveStrength", RuntimeMaterial.EmissiveStrength);

--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -346,7 +346,7 @@ UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(const int32 Index,
 
 			if (!(*JsonMaterialIridescence)->TryGetNumberField(TEXT("iridescenceThicknessMinimum"), RuntimeMaterial.IridescenceThicknessMinimum))
 			{
-				RuntimeMaterial.IridescenceThicknessMinimum = 200;
+				RuntimeMaterial.IridescenceThicknessMinimum = 100;
 			}
 
 			if (!(*JsonMaterialIridescence)->TryGetNumberField(TEXT("iridescenceThicknessMaximum"), RuntimeMaterial.IridescenceThicknessMaximum))

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -2202,6 +2202,19 @@ struct FglTFRuntimeMaterial
 	FglTFRuntimeTextureTransform SheenRoughnessTextureTransform;
 	FglTFRuntimeTextureSampler SheenRoughnessTextureSampler;
 
+	bool bKHR_materials_iridescence;
+	double IridescenceFactor;
+	double IridescenceIor;
+	double IridescenceThicknessMaximum;
+	double IridescenceThicknessMinimum;
+	UTexture2D* IridescenceTextureCache;
+	TArray<FglTFRuntimeMipMap> IridescenceTextureMips;
+	FglTFRuntimeTextureSampler IridescenceTextureSampler;
+	FglTFRuntimeTextureTransform IridescenceTextureTransform;
+	UTexture2D* IridescenceThicknessTextureCache;
+	TArray<FglTFRuntimeMipMap> IridescenceThicknessTextureMips;
+	FglTFRuntimeTextureSampler IridescenceThicknessTextureSampler;
+	FglTFRuntimeTextureTransform IridescenceThicknessTextureTransform;
 
 	FglTFRuntimeMaterial()
 	{
@@ -2253,6 +2266,13 @@ struct FglTFRuntimeMaterial
 		SheenRoughnessFactor = 0;
 		SheenColorTextureCache = nullptr;
 		SheenRoughnessTextureCache = nullptr;
+		bKHR_materials_iridescence = false;
+		IridescenceFactor = 0;
+		IridescenceIor = 1.3;
+		IridescenceThicknessMaximum = 400;
+		IridescenceThicknessMinimum = 100;
+		IridescenceTextureCache = nullptr;
+		IridescenceThicknessTextureCache = nullptr;
 	}
 };
 


### PR DESCRIPTION
The support is limited to reading the KHR_materials_iridescence parameters from the source file and setting them in the UE Material, which is not provided.

<img width="1083" height="752" alt="image" src="https://github.com/user-attachments/assets/103c0525-4ee4-4cbd-8ad2-c8cb3c67295f" />

[https://blueprintue.com/blueprint/88xts-t1/](https://blueprintue.com/blueprint/88xts-t1/)