### PR TITLE
Fix UE5.8 FJsonObject::Values key type incompatibility

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
@@ -1655,22 +1655,22 @@ TMap<FString, FString> UglTFRuntimeAsset::GetAssetMeta() const
 
 	if (JsonObject)
 	{
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : JsonObject->Values)
+		for (const auto& Pair : JsonObject->Values)
 		{
 			if (!Pair.Value.IsValid())
 			{
-				Meta.Add(Pair.Key, "");
+				Meta.Add(FString(Pair.Key), "");
 				continue;
 			}
 
 			FString Value;
 			if (!Pair.Value->TryGetString(Value))
 			{
-				Meta.Add(Pair.Key, "");
+				Meta.Add(FString(Pair.Key), "");
 				continue;
 			}
 
-			Meta.Add(Pair.Key, Value);
+			Meta.Add(FString(Pair.Key), Value);
 		}
 	}
 

--- a/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
@@ -6100,7 +6100,7 @@ bool FglTFRuntimeParser::GetStringMapFromExtras(const FString& Key, TMap<FString
 		return false;
 	}
 
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*JsonExtraObject)->Values)
+	for (const auto& Pair : (*JsonExtraObject)->Values)
 	{
 		if (!Pair.Value.IsValid())
 		{
@@ -6113,7 +6113,7 @@ bool FglTFRuntimeParser::GetStringMapFromExtras(const FString& Key, TMap<FString
 			continue;
 		}
 
-		StringMap.Add(Pair.Key, Value);
+		StringMap.Add(FString(Pair.Key), Value);
 	}
 
 	return true;

--- a/Source/glTFRuntime/Private/glTFRuntimeParserCustom.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserCustom.cpp
@@ -263,22 +263,22 @@ TMap<FString, FString> FglTFRuntimeParser::GetJSONStringMapFromPath(const TArray
 		if (CurrentObject->TryGetObject(JsonObject))
 		{
 			bFound = true;
-			for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*JsonObject)->Values)
+			for (const auto& Pair : (*JsonObject)->Values)
 			{
 				if (!Pair.Value.IsValid())
 				{
-					StringMap.Add(Pair.Key, "");
+					StringMap.Add(FString(Pair.Key), "");
 					continue;
 				}
 
 				FString Value;
 				if (!Pair.Value->TryGetString(Value))
 				{
-					StringMap.Add(Pair.Key, "");
+					StringMap.Add(FString(Pair.Key), "");
 					continue;
 				}
 
-				StringMap.Add(Pair.Key, Value);
+				StringMap.Add(FString(Pair.Key), Value);
 			}
 		}
 	}

--- a/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
@@ -2975,11 +2975,11 @@ UAnimSequence* FglTFRuntimeParser::CreateSkeletalAnimationFromPath(USkeletalMesh
 		const TSharedPtr<FJsonObject>* JsonFrameObject = nullptr;
 		if (JsonFrame->TryGetObject(JsonFrameObject))
 		{
-			for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*JsonFrameObject)->Values)
+			for (const auto& Pair : (*JsonFrameObject)->Values)
 			{
-				if (!MorphTargetCurves.Contains(*Pair.Key))
+				if (!MorphTargetCurves.Contains(*FString(Pair.Key)))
 				{
-					MorphTargetCurves.Add(*Pair.Key);
+					MorphTargetCurves.Add(*FString(Pair.Key));
 				}
 			}
 		}

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -2701,11 +2701,11 @@ public:
 	template<typename Callback, typename... Args>
 	void ForEachJsonField(TSharedRef<FJsonObject> JsonObject, Callback InCallback, Args... InArgs)
 	{
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : JsonObject->Values)
+		for (const auto& Pair : JsonObject->Values)
 		{
 			if (Pair.Value.IsValid())
 			{
-				InCallback(Pair.Key, Pair.Value.ToSharedRef(), InArgs...);
+				InCallback(FString(Pair.Key), Pair.Value.ToSharedRef(), InArgs...);
 			}
 		}
 	}


### PR DESCRIPTION
In UE 5.8, FJsonObject::Values changed its key type from FString to UE::TSharedString<char16_t>. Range-for loops bound to `const TPair<FString, TSharedPtr<FJsonValue>>&` now construct a temporary (implicit FString conversion), which Clang rejects as -Werror,-Wrange-loop-construct.

Fix: use `const auto&` for the loop variable in all five affected JsonObject->Values iterations, and explicitly wrap Pair.Key with FString() at each call site that requires FString (TMap::Add, MorphTargetCurves::Contains/Add, ForEachJsonField callback).

Affected files:
  glTFRuntimeParser.h          (ForEachJsonField template)
  glTFRuntimeAsset.cpp         (GetAssetMeta)
  glTFRuntimeParser.cpp        (GetStringMapFromExtras)
  glTFRuntimeParserCustom.cpp  (GetJSONStringMapFromPath)
  glTFRuntimeParserSkeletalMeshes.cpp (CreateSkeletalAnimationFromPath)