### PR TITLE
Fix morph targets being silently dropped on all primitives after the first (indexed meshes)

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
@@ -1022,7 +1022,9 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 				{
 					bool bSkip = true;
 					FMorphTargetLODModel MorphTargetLODModel;
-					MorphTargetLODModel.NumBaseMeshVerts = Primitive.Indices.Num();
+					// SourceIdx indexes the render vertex buffer, whose per-section base
+					// advances by Positions.Num() (see MeshSection.BaseVertexIndex above)
+					MorphTargetLODModel.NumBaseMeshVerts = Primitive.Positions.Num();
 					MorphTargetLODModel.SectionIndices.Add(PrimitiveIndex);
 
 					for (int32 VertexIndex = 0; VertexIndex < Primitive.Positions.Num(); VertexIndex++)
@@ -1144,7 +1146,7 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 
 					MorphTargetIndex++;
 				}
-				BaseIndex += Primitive.Indices.Num();
+				BaseIndex += Primitive.Positions.Num();
 			}
 		}
 


### PR DESCRIPTION
## Problem

On a skeletal mesh built from multiple primitives, morph targets only work on the first primitive. Morph targets belonging to every subsequent primitive have no visual effect — no error, no warning, the deltas are just silently dropped by the engine. This is most visible on character models where the face is not the first primitive: all facial blendshapes appear dead.

This matches the old report in #6 ("Morph targets not imported correctly with multiple bodies").

## Root cause

`FMorphTargetDelta::SourceIdx` must index into the LOD **vertex buffer**. In `FinalizeSkeletalMeshWithLODs` the render sections are laid out with a per-primitive vertex base that advances by `Positions.Num()` (`MeshSection.BaseVertexIndex`, incremented per vertex).

The morph-target building loop, however, advances its base by the **index count**:

```cpp
MorphTargetLODModel.NumBaseMeshVerts = Primitive.Indices.Num();
...
BaseIndex += Primitive.Indices.Num();
```

For indexed primitives `Indices.Num()` is (much) larger than `Positions.Num()`, so starting from the second primitive every delta's `SourceIdx` points past the primitive's real vertex range. When the engine builds the morph vertex buffers it range-checks `SourceIdx` and silently discards the out-of-range deltas, so those morph targets do nothing.

## Fix

Advance the morph base (and `NumBaseMeshVerts`) by `Positions.Num()`, matching the render vertex buffer layout. Two-line change, no API impact. Single-primitive meshes are unaffected (their base is 0 either way), which is why the bug is easy to miss.

## Verified

UE 5.7, GLB with 7 primitives / 89 morph targets spread across face+eye+hair primitives: before the fix only the first primitive's morphs worked; after the fix all 89 match an editor FBX import of the same model 1:1 (visually verified in PIE via SetMorphTarget on every channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
