### PR TITLE
Fix Clang range-loop warning + TSharedString compatibility on UE 5.8.1

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAsset.cpp
@@ -1655,22 +1655,22 @@ TMap<FString, FString> UglTFRuntimeAsset::GetAssetMeta() const
 
 	if (JsonObject)
 	{
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : JsonObject->Values)
+		for (const auto& Pair : JsonObject->Values)
 		{
 			if (!Pair.Value.IsValid())
 			{
-				Meta.Add(Pair.Key, "");
+				Meta.Add(FString(Pair.Key), "");
 				continue;
 			}
 
 			FString Value;
 			if (!Pair.Value->TryGetString(Value))
 			{
-				Meta.Add(Pair.Key, "");
+				Meta.Add(FString(Pair.Key), "");
 				continue;
 			}
 
-			Meta.Add(Pair.Key, Value);
+			Meta.Add(FString(Pair.Key), Value);
 		}
 	}
 

--- a/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParser.cpp
@@ -6142,7 +6142,7 @@ bool FglTFRuntimeParser::GetStringMapFromExtras(const FString& Key, TMap<FString
 		return false;
 	}
 
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*JsonExtraObject)->Values)
+	for (const auto& Pair : (*JsonExtraObject)->Values)
 	{
 		if (!Pair.Value.IsValid())
 		{
@@ -6155,7 +6155,7 @@ bool FglTFRuntimeParser::GetStringMapFromExtras(const FString& Key, TMap<FString
 			continue;
 		}
 
-		StringMap.Add(Pair.Key, Value);
+		StringMap.Add(FString(Pair.Key), Value);
 	}
 
 	return true;

--- a/Source/glTFRuntime/Private/glTFRuntimeParserCustom.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserCustom.cpp
@@ -263,22 +263,22 @@ TMap<FString, FString> FglTFRuntimeParser::GetJSONStringMapFromPath(const TArray
 		if (CurrentObject->TryGetObject(JsonObject))
 		{
 			bFound = true;
-			for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*JsonObject)->Values)
+			for (const auto& Pair : (*JsonObject)->Values)
 			{
 				if (!Pair.Value.IsValid())
 				{
-					StringMap.Add(Pair.Key, "");
+					StringMap.Add(FString(Pair.Key), "");
 					continue;
 				}
 
 				FString Value;
 				if (!Pair.Value->TryGetString(Value))
 				{
-					StringMap.Add(Pair.Key, "");
+					StringMap.Add(FString(Pair.Key), "");
 					continue;
 				}
 
-				StringMap.Add(Pair.Key, Value);
+				StringMap.Add(FString(Pair.Key), Value);
 			}
 		}
 	}

--- a/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
@@ -2963,7 +2963,7 @@ UAnimSequence* FglTFRuntimeParser::CreateSkeletalAnimationFromPath(USkeletalMesh
 		const TSharedPtr<FJsonObject>* JsonFrameObject = nullptr;
 		if (JsonFrame->TryGetObject(JsonFrameObject))
 		{
-			for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*JsonFrameObject)->Values)
+			for (const auto& Pair : (*JsonFrameObject)->Values)
 			{
 				if (!MorphTargetCurves.Contains(*Pair.Key))
 				{

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -2701,7 +2701,7 @@ public:
 	template<typename Callback, typename... Args>
 	void ForEachJsonField(TSharedRef<FJsonObject> JsonObject, Callback InCallback, Args... InArgs)
 	{
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : JsonObject->Values)
+		for (const auto& Pair : JsonObject->Values)
 		{
 			if (Pair.Value.IsValid())
 			{


### PR DESCRIPTION
This fixes Android packaging errors with UE 5.8.1.

Changes:
- Replace explicit TPair types with auto references to avoid Clang range-loop warnings.
- Update JSON key handling to support UE 5.8.1's TSharedString implementation.

The issue only appeared on Android because Clang treats the warning as an error with -Werror.