### PR TITLE
Fix morph target SourceIdx using the index-buffer base as a vertex base

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
@@ -999,7 +999,11 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 			TMap<FString, UMorphTarget*> MorphTargetNamesHistory;
 			TMap<FString, int32> MorphTargetNamesDuplicateCounter;
 
-			int32 BaseIndex = 0;
+			// FMorphTargetDelta::SourceIdx addresses the LOD's vertex buffer, so this base must
+			// track FSkelMeshRenderSection::BaseVertexIndex in FillSkeletalMeshRenderData, which
+			// accumulates Positions.Num(). Advancing it by Indices.Num() instead placed every
+			// primitive after the first past the end of the vertex buffer.
+			int32 BaseVertexIndex = 0;
 
 			for (int32 PrimitiveIndex = 0; PrimitiveIndex < SkeletalMeshContext->LODs[LODIndex]->Primitives.Num(); PrimitiveIndex++)
 			{
@@ -1010,7 +1014,7 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 				{
 					bool bSkip = true;
 					FMorphTargetLODModel MorphTargetLODModel;
-					MorphTargetLODModel.NumBaseMeshVerts = Primitive.Indices.Num();
+					MorphTargetLODModel.NumBaseMeshVerts = Primitive.Positions.Num();
 					MorphTargetLODModel.SectionIndices.Add(PrimitiveIndex);
 
 					for (int32 VertexIndex = 0; VertexIndex < Primitive.Positions.Num(); VertexIndex++)
@@ -1038,7 +1042,7 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 							bSkip = false;
 						}
 
-						Delta.SourceIdx = BaseIndex + VertexIndex;
+						Delta.SourceIdx = BaseVertexIndex + VertexIndex;
 #if ENGINE_MAJOR_VERSION > 4
 						Delta.TangentZDelta = FVector3f::ZeroVector;
 #else
@@ -1132,7 +1136,7 @@ USkeletalMesh* FglTFRuntimeParser::FinalizeSkeletalMeshWithLODs(TSharedRef<FglTF
 
 					MorphTargetIndex++;
 				}
-				BaseIndex += Primitive.Indices.Num();
+				BaseVertexIndex += Primitive.Positions.Num();
 			}
 		}
 


### PR DESCRIPTION
## The bug

In `FinalizeSkeletalMeshWithLODs`, the morph-target loop computes

```cpp
Delta.SourceIdx = BaseIndex + VertexIndex;
```

and advances its base per primitive with

```cpp
BaseIndex += Primitive.Indices.Num();
```

But `FMorphTargetDelta::SourceIdx` addresses the LOD's **vertex** buffer, not the index
buffer. `FillSkeletalMeshRenderData` keeps two separate counters precisely because these
are different quantities:

* `BaseIndex` — index-buffer offset, advanced by `Primitive.Indices.Num()`
* `BaseVertexIndex` — vertex-buffer offset, incremented once per vertex, and what
  `FSkelMeshRenderSection::BaseVertexIndex` is set from

The morph loop keeps only one counter and uses it in both roles. For any mesh with more
than one primitive the two diverge immediately.

## Why it is easy to miss

It fails **silently and completely**. The deltas are computed correctly and stored
correctly; only their indices are wrong. So:

* no warning or error is emitted,
* `USkeletalMeshComponent::MorphTargetWeights` and `ActiveMorphTargets` populate normally,
* anim curves drive the weights normally,
* inspecting `UMorphTarget::GetMorphLODModels()[0].Vertices` shows correct
  `PositionDelta` magnitudes,

and the mesh simply never deforms. Everything you would think to check reports success.

## Concrete example

A 9-primitive skinned character (4737 vertices, 19860 indices). Morph deltas for
primitive 3, whose vertices occupy 2464–3845:

| primitive | verts | indices | correct base | base actually used |
|---|---|---|---|---|
| 0 | 2412 | 10059 | 0 | 0 |
| 1 | 26 | 120 | 2412 | 10059 |
| 2 | 26 | 120 | 2438 | 10179 |
| 3 | 1382 | 6909 | **2464** | **10299** |
| 4 | 321 | 837 | 3846 | 17208 |

Primitive 3's deltas are written to `SourceIdx` 10299–11680, past the end of a
4737-vertex buffer, so the GPU discards them entirely. Only primitive 0 (base 0) is ever
correct — which is why a single-primitive mesh works fine and a multi-material one does
not.

## The fix

Track the vertex base the same way `FillSkeletalMeshRenderData` does, and set
`NumBaseMeshVerts` from the same count:

```cpp
int32 BaseVertexIndex = 0;
...
MorphTargetLODModel.NumBaseMeshVerts = Primitive.Positions.Num();
...
Delta.SourceIdx = BaseVertexIndex + VertexIndex;
...
BaseVertexIndex += Primitive.Positions.Num();
```

## Verification

Found while adding facial animation to a multi-material character (head, body, eyes,
teeth, tongue, beard as separate glTF primitives). Before the change, every facial morph
target — lids, jaw, mouth — animated its weight to 1.0 with no visible deformation; the
only unaffected primitive was the one at base 0, which carried no morphs. After the
change, all of them deform correctly, verified in-engine on UE 5.8.
